### PR TITLE
Make docker compose runtime file unique and auto deleted

### DIFF
--- a/src/zrb/builtin/generator/fastapp_module/add.py
+++ b/src/zrb/builtin/generator/fastapp_module/add.py
@@ -202,7 +202,7 @@ def _get_new_docker_compose_service_definition(
                 'context': './src'
             },
             'image': '${IMAGE:-' + kebab_app_name + '}',
-            'container_name': f'{kebab_app_name}-{kebab_module_name}-service',
+            'container_name': '${CONTAINER_PREFIX:-my}-' + f'{kebab_app_name}-{kebab_module_name}-service', # noqa
             'hostname': f'{kebab_app_name}-{kebab_module_name}-service',
             'env_file': [
                 'src/template.env',

--- a/src/zrb/helper/accessories/name.py
+++ b/src/zrb/helper/accessories/name.py
@@ -5,7 +5,7 @@ import string
 def get_random_name(
     separator: str = '-',
     add_random_digit: bool = True,
-    digit_count: int = 3
+    digit_count: int = 4
 ) -> str:
     prefixes = [
         "aurum", "argentum", "platinum", "mercurius", "sulfur", "sal",


### PR DESCRIPTION
Everytime docker-compose task is executed, a runtime file will be created to accommodate ServiceConfig.
Previously, the same docker-compose task will share the same runtime file.

In this PR, the runtime file is now unique (per session), and will be automatically deleted once used.