### PR TITLE
WIP: Add default and callback to base input

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -62,17 +62,28 @@ Zrb log verbosity.
 Default shell to run Cmd Task (should be `bash` compatible).
 
 - __Default value:__ `zsh` or `bash`, depending on `$SHELL`
-- __Possible value:__
+- __Possible values:__
     - `/usr/bin/zsh` 
     - `/usr/bin/bash`
     - etc.
 
 > __⚠️ WARNING:__ Stick with bash compatible shell. Most builtin tasks are written for bash scripts.
 
+## `ZRB_EDITOR`
+
+- __Default value:__ `nano`
+- __Possible values:__ 
+  - `nano`
+  - `vi`
+  - `vim`
+  - `nvim`
+  - `hx`
+  - etc.
+
 ## `ZRB_TMP_DIR`
 
 - __Default value:__ `/tmp`
-- __Possible value:__ Any existing directory path
+- __Possible values:__ Any existing directory path
 
 
 ## `ZRB_SHOULD_LOAD_BULTIN`
@@ -80,28 +91,28 @@ Default shell to run Cmd Task (should be `bash` compatible).
 Whether Zrb should load the builtin tasks or not.
 
 - __Default value:__ `true`
-- __Possible value:__ boolean values
+- __Possible values:__ boolean values
 
 ## `ZRB_SHOW_ADVERTISEMENT`
 
 Whether Zrb should load show advertisement or not.
 
 - __Default value:__ `true`
-- __Possible value:__ boolean values
+- __Possible values:__ boolean values
 
 ## `ZRB_SHOW_PROMPT`
 
 Whether Zrb should always show prompt or not.
 
 - __Default value:__ `true`
-- __Possible value:__ boolean values
+- __Possible values:__ boolean values
 
 ## `ZRB_SHOW_TIME`
 
 Whether Zrb should log the time or not.
 
 - __Default value:__ `true`
-- __Possible value:__ boolean values
+- __Possible values:__ boolean values
 
 ## `ZRB_ENABLE_TYPE_CHECKING`
 
@@ -110,12 +121,12 @@ Whether Zrb should check data type or not.
 Although it is safer to enable type checking, you can improve Zrb performance by turning off type checking.
 
 - __Default value:__ `true`
-- __Possible value:__ boolean values
+- __Possible values:__ boolean values
 
 ## `ZRB_CONTAINER_BACKEND`
 
 - __Default value:__ `docker`
-- __Possible value:__ `docker`, `podman`
+- __Possible values:__ `docker`, `podman`
 
 
 🔖 [Table of Contents](README.md)

--- a/docs/technical-documentation/task-inputs/README.md
+++ b/docs/technical-documentation/task-inputs/README.md
@@ -9,6 +9,7 @@
 - [ChoiceInput](choice-input.md)
 - [FloatInput](float-input.md)
 - [IntInput](int-input.md)
+- [MultilineInput](multiline-input.md)
 - [PasswordInput](password-input.md)
 - [StrInput](str-input.md)
 

--- a/docs/technical-documentation/task-inputs/base-input.md
+++ b/docs/technical-documentation/task-inputs/base-input.md
@@ -16,8 +16,9 @@ __Attributes:__
 - `name` (`str`): The name of the input, used as a unique identifier.
 - `shortcut` (`Optional[str]`): An optional single-character shortcut for the input.
 - `default` (`Optional[Any]`): The default value of the input.
+- `callback` (`Optional[Any]`): The default value of the input.
 - `description` (`Optional[str]`): A brief description of what the input is for.
-- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines whether the default value should be displayed.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): The prompt text to be displayed when asking for the input.
 - `confirmation_prompt` (`Union[bool, str]`): A prompt for confirmation if required.
 - `prompt_required` (`bool`): Indicates whether a prompt is required.
@@ -45,6 +46,16 @@ task = Task(
     ]
 )
 ```
+
+
+### `BaseInput._wrapped_callback`
+
+No documentation available.
+
+
+### `BaseInput._wrapped_default`
+
+No documentation available.
 
 
 ### `BaseInput.get_default`

--- a/docs/technical-documentation/task-inputs/bool-input.md
+++ b/docs/technical-documentation/task-inputs/bool-input.md
@@ -16,9 +16,10 @@ __Arguments:__
 
 - `name` (`str`): The name of the input.
 - `shortcut` (`Optional[str]`): A shortcut string for the input.
-- `default` (`Optional[Any]`): The default value for the input. Should be a boolean if set.
-- `description` (`Optional[str]`): A brief description of the input.
-- `show_default` (`Union[bool, str, None]`): Option to display the default value. Can be a boolean or string representation.
+- `default` (`Optional[Any]`): The default value of the input.
+- `callback` (`Optional[Any]`): The default value of the input.
+- `description` (`Optional[str]`): A brief description of what the input is for.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If set to `True`, the user is asked to confirm the input.
 - `prompt_required` (`bool`): If `True`, the prompt for input is mandatory.
@@ -44,6 +45,16 @@ bool_input.get_default()
 ```
 False
 ```
+
+
+### `BoolInput._wrapped_callback`
+
+No documentation available.
+
+
+### `BoolInput._wrapped_default`
+
+No documentation available.
 
 
 ### `BoolInput.get_default`

--- a/docs/technical-documentation/task-inputs/choice-input.md
+++ b/docs/technical-documentation/task-inputs/choice-input.md
@@ -19,8 +19,9 @@ __Arguments:__
 - `shortcut` (`Optional[str]`): An optional shortcut string for the input.
 - `choices` (`Iterable[Any]`): An iterable of choices from which the user can select.
 - `default` (`Optional[Any]`): The default value for the input. Should be one of the choices if set.
-- `description` (`Optional[str]`): A brief description of the input.
-- `show_default` (`Union[bool, str, None]`): Option to display the default value. Can be a boolean or string representation.
+- `callback` (`Optional[Any]`): The default value of the input.
+- `description` (`Optional[str]`): A brief description of what the input is for.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If set to `True`, the user is asked to confirm the input.
 - `prompt_required` (`bool`): If `True`, the prompt for input is mandatory.
@@ -46,6 +47,16 @@ choice_input.get_default()
 ```
 'red'
 ```
+
+
+### `ChoiceInput._wrapped_callback`
+
+No documentation available.
+
+
+### `ChoiceInput._wrapped_default`
+
+No documentation available.
 
 
 ### `ChoiceInput.get_default`

--- a/docs/technical-documentation/task-inputs/input.md
+++ b/docs/technical-documentation/task-inputs/input.md
@@ -14,8 +14,9 @@ __Attributes:__
 - `name` (`str`): The name of the input, used as a unique identifier.
 - `shortcut` (`Optional[str]`): An optional single-character shortcut for the input.
 - `default` (`Optional[Any]`): The default value of the input.
+- `callback` (`Optional[Any]`): The default value of the input.
 - `description` (`Optional[str]`): A brief description of what the input is for.
-- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines whether the default value should be displayed.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): The prompt text to be displayed when asking for the input.
 - `confirmation_prompt` (`Union[bool, str]`): A prompt for confirmation if required.
 - `prompt_required` (`bool`): Indicates whether a prompt is required.
@@ -43,6 +44,16 @@ task = Task(
     ]
 )
 ```
+
+
+### `Input._wrapped_callback`
+
+No documentation available.
+
+
+### `Input._wrapped_default`
+
+No documentation available.
 
 
 ### `Input.get_default`

--- a/docs/technical-documentation/task-inputs/int-input.md
+++ b/docs/technical-documentation/task-inputs/int-input.md
@@ -18,8 +18,9 @@ __Arguments:__
 - `name` (`str`): The name of the input, serving as an identifier.
 - `shortcut` (`Optional[str]`): An optional shortcut for easier reference to the input.
 - `default` (`Optional[Any]`): The default value for the input, should be an integer if provided.
-- `description` (`Optional[str]`): A brief description of what the input represents or its intended use.
-- `show_default` (`Union[bool, str, None]`): Option to show the default value in prompts or documentation.
+- `callback` (`Optional[Any]`): The default value of the input.
+- `description` (`Optional[str]`): A brief description of what the input is for.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to determine the prompt for user input. If `True`, uses a default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If `True`, the user will be asked to confirm their input.
 - `prompt_required` (`bool`): If `True`, makes the input prompt mandatory.
@@ -45,6 +46,16 @@ int_input.get_default()
 ```
 30
 ```
+
+
+### `IntInput._wrapped_callback`
+
+No documentation available.
+
+
+### `IntInput._wrapped_default`
+
+No documentation available.
 
 
 ### `IntInput.get_default`

--- a/docs/technical-documentation/task-inputs/multiline-input.md
+++ b/docs/technical-documentation/task-inputs/multiline-input.md
@@ -1,63 +1,64 @@
 🔖 [Table of Contents](../../README.md) / [Technical Documentation](../README.md) / [Task Inputs](README.md)
 
-# FloatInput
+# MultilineInput
 
 # Technical Specification
 
 <!--start-doc-->
-## `FloatInput`
+## `MultilineInput`
 
-A specialized input class designed to handle floating-point numbers in a task input context.
+A specialized input class for handling string-based inputs in various tasks.
 
-Extending `BaseInput`, this class facilitates the handling of float-type inputs, accommodating
-various features like default values, prompts, flags, and customization options.
+`StrInput` extends `BaseInput` to manage string-type inputs, supporting features like
+default values, prompts, flags, and other customization options. This class is useful
+for tasks requiring textual input, such as names, descriptions, or any other string parameters.
 
 __Arguments:__
 
-- `name` (`str`): The name of the input.
+- `name` (`str`): The name of the input, used as an identifier.
 - `shortcut` (`Optional[str]`): An optional shortcut string for the input.
-- `default` (`Optional[Any]`): The default value for the input, expected to be a float if set.
+- `default` (`Optional[Any]`): The default value for the input, expected to be a string if set.
 - `callback` (`Optional[Any]`): The default value of the input.
 - `description` (`Optional[str]`): A brief description of what the input is for.
 - `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If `True`, the user is asked to confirm the input.
-- `prompt_required` (`bool`): If `True`, the prompt for input is mandatory.
-- `hide_input` (`bool`): If `True`, the input is hidden, useful for sensitive information.
-- `is_flag` (`Optional[bool]`): Indicates if the input is a flag. If `True`, the input accepts boolean flag values.
+- `prompt_required` (`bool`): If `True’, the prompt for input is mandatory.
+- `hide_input` (`bool`): If `True’, hides the input value, typically used for sensitive data.
+- `is_flag` (`Optional[bool]`): Indicates if the input is a flag. If `True’, the input accepts boolean flag values.
 - `flag_value` (`Optional[Any]`): The value associated with the flag if `is_flag` is `True`.
-- `multiple` (`bool`): If `True`, allows multiple float values for the input.
-- `count` (`bool`): If `True`, counts the occurrences of the input.
-- `allow_from_autoenv` (`bool`): If `True`, allows the input to be automatically populated from the environment.
-- `hidden` (`bool`): If `True`, the input is not shown in help messages or documentation.
-- `show_choices` (`bool`): If `True`, displays the available choices to the user (relevant if there are restricted float choices).
-- `show_envvar` (`bool`): Indicates whether to display the environment variable associated with this input.
+- `multiple` (`bool`): If `True’, allows multiple string values for the input.
+- `count` (`bool`): If `True’, counts the occurrences of the input.
+- `allow_from_autoenv` (`bool`): If `True’, enables automatic population of the input from environment variables.
+- `hidden` (`bool`): If `True’, keeps the input hidden in help messages or documentation.
+- `show_choices` (`bool`): If `True’, shows any restricted choices for the input value.
+- `show_envvar` (`bool`): If `True’, displays the associated environment variable, if applicable.
 - `nargs` (`int`): The number of arguments that the input can accept.
-- `should_render` (`bool`): If `True`, the input is rendered in the UI or command-line interface.
+- `should_render` (`bool`): If `True’, renders the input in the user interface or command-line interface.
 
 __Examples:__
 
 ```python
-float_input = FloatInput(name='threshold', default=0.5, description='Set the threshold value')
-float_input.get_default()
+multiline_input = StrInput(name='username', default='user123', description='Enter your username')
+multiline_input.get_default()
 ```
 
 ```
-0.5
+'user123'
 ```
 
 
-### `FloatInput._wrapped_callback`
+### `MultilineInput._wrapped_callback`
 
 No documentation available.
 
 
-### `FloatInput._wrapped_default`
+### `MultilineInput._wrapped_default`
 
 No documentation available.
 
 
-### `FloatInput.get_default`
+### `MultilineInput.get_default`
 
 Obtains the default value of the input.
 
@@ -65,7 +66,7 @@ __Returns:__
 
 `Any`: The default value of the input. The type can be any, depending on the input specification.
 
-### `FloatInput.get_name`
+### `MultilineInput.get_name`
 
 Retrieves the name of the input.
 
@@ -73,7 +74,7 @@ __Returns:__
 
 `str`: The name of the input.
 
-### `FloatInput.get_options`
+### `MultilineInput.get_options`
 
 Provides a mapping (dictionary) representing the input.
 
@@ -81,7 +82,7 @@ __Returns:__
 
 `Mapping[str, Any]`: A dictionary where keys are option names and values are the corresponding details.
 
-### `FloatInput.get_param_decl`
+### `MultilineInput.get_param_decl`
 
 Fetches a list of parameter option associated with the input (i.e., `-f` or `--file`).
 
@@ -89,7 +90,7 @@ __Returns:__
 
 `List[str]`: A list containing strings of parameter options.
 
-### `FloatInput.is_hidden`
+### `MultilineInput.is_hidden`
 
 Checks whether the input value is meant to be hidden from view or output.
 
@@ -97,7 +98,7 @@ __Returns:__
 
 `bool`: True if the input is hidden, False otherwise.
 
-### `FloatInput.should_render`
+### `MultilineInput.should_render`
 
 Determines whether or not the input should be rendered.
 

--- a/docs/technical-documentation/task-inputs/password-input.md
+++ b/docs/technical-documentation/task-inputs/password-input.md
@@ -19,8 +19,9 @@ __Arguments:__
 - `name` (`str`): The name of the input, serving as an identifier.
 - `shortcut` (`Optional[str]`): An optional shortcut string for the input.
 - `default` (`Optional[Any]`): The default value for the input, expected to be a string if set.
-- `description` (`Optional[str]`): A brief description of the input's purpose.
-- `show_default` (`Union[bool, str, None]`): Option to display the default value. Can be a boolean or string.
+- `callback` (`Optional[Any]`): The default value of the input.
+- `description` (`Optional[str]`): A brief description of what the input is for.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If `True`, the user is asked to confirm the input.
 - `prompt_required` (`bool`): If `True`, the prompt for input is mandatory.
@@ -45,6 +46,16 @@ password_input.is_hidden()
 ```
 True
 ```
+
+
+### `PasswordInput._wrapped_callback`
+
+No documentation available.
+
+
+### `PasswordInput._wrapped_default`
+
+No documentation available.
 
 
 ### `PasswordInput.get_default`

--- a/docs/technical-documentation/task-inputs/str-input.md
+++ b/docs/technical-documentation/task-inputs/str-input.md
@@ -18,8 +18,9 @@ __Arguments:__
 - `name` (`str`): The name of the input, used as an identifier.
 - `shortcut` (`Optional[str]`): An optional shortcut string for the input.
 - `default` (`Optional[Any]`): The default value for the input, expected to be a string if set.
-- `description` (`Optional[str]`): A brief description of the input's purpose.
-- `show_default` (`Union[bool, str, None]`): Option to display the default value. Can be a boolean or string.
+- `callback` (`Optional[Any]`): The default value of the input.
+- `description` (`Optional[str]`): A brief description of what the input is for.
+- `show_default` (`Union[bool, JinjaTemplate, None]`): Determines the default value to be shown.
 - `prompt` (`Union[bool, str]`): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
 - `confirmation_prompt` (`Union[bool, str]`): If `True`, the user is asked to confirm the input.
 - `prompt_required` (`bool`): If `True’, the prompt for input is mandatory.
@@ -45,6 +46,16 @@ str_input.get_default()
 ```
 'user123'
 ```
+
+
+### `StrInput._wrapped_callback`
+
+No documentation available.
+
+
+### `StrInput._wrapped_default`
+
+No documentation available.
 
 
 ### `StrInput.get_default`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zrb"
-version = "0.18.1"
+version = "0.19.0"
 description = "A Framework to Enhance Your Workflow"
 authors = ["Go Frendi Gunawan <gofrendiasgard@gmail.com>"]
 license = "AGPL-3.0-or-later"

--- a/src/zrb/__init__.py
+++ b/src/zrb/__init__.py
@@ -45,6 +45,7 @@ from zrb.task_input.bool_input import BoolInput
 from zrb.task_input.choice_input import ChoiceInput
 from zrb.task_input.float_input import FloatInput
 from zrb.task_input.int_input import IntInput
+from zrb.task_input.multiline_input import MultilineInput
 from zrb.task_input.password_input import PasswordInput
 from zrb.task_input.str_input import StrInput
 from zrb.task_input.task_input import Input
@@ -93,6 +94,7 @@ assert BoolInput
 assert ChoiceInput
 assert FloatInput
 assert IntInput
+assert MultilineInput
 assert PasswordInput
 assert StrInput
 assert Env

--- a/src/zrb/config/config.py
+++ b/src/zrb/config/config.py
@@ -32,6 +32,7 @@ def _get_default_tmp_dir() -> str:
 
 tmp_dir = os.getenv("ZRB_TMP_DIR", _get_default_tmp_dir())
 default_shell = os.getenv("ZRB_SHELL", _get_current_shell())
+default_editor = os.getenv("ZRB_EDITOR", "nano")
 init_script_str = os.getenv("ZRB_INIT_SCRIPTS", "")
 init_scripts = init_script_str.split(":") if init_script_str != "" else []
 logging_level = untyped_to_logging_level(os.getenv("ZRB_LOGGING_LEVEL", "WARNING"))

--- a/src/zrb/helper/multilline.py
+++ b/src/zrb/helper/multilline.py
@@ -1,5 +1,6 @@
-from zrb.helper.typecheck import typechecked
 import click
+
+from zrb.helper.typecheck import typechecked
 
 
 @typechecked

--- a/src/zrb/helper/multilline.py
+++ b/src/zrb/helper/multilline.py
@@ -1,0 +1,10 @@
+from zrb.helper.typecheck import typechecked
+import click
+
+
+@typechecked
+def edit(editor: str, mark_comment: str, text: str) -> str:
+    result = click.edit(text="\n".join([mark_comment, text]), editor=editor)
+    if result is None:
+        result = text
+    return "\n".join(result.split(mark_comment)).strip()

--- a/src/zrb/task_input/base_input.py
+++ b/src/zrb/task_input/base_input.py
@@ -133,14 +133,14 @@ class BaseInput(AnyInput):
             "show_choices": self._show_choices,
             "show_envvar": self._show_envvar,
             "nargs": self._nargs,
-            "callback": self.__wrapped_callback,
-            "default": self.__wrapped_default,
+            "callback": self._wrapped_callback,
+            "default": self._wrapped_default,
         }
         if show_prompt:
             options["prompt"] = self._prompt
         return options
 
-    def __wrapped_callback(self, ctx, param, value) -> Any:
+    def _wrapped_callback(self, ctx, param, value) -> Any:
         if self.get_name() not in self.__input_value_map:
             if callable(self._callback):
                 result = self._callback(self.__input_value_map)
@@ -150,7 +150,7 @@ class BaseInput(AnyInput):
             return value
         return self.__input_value_map[self.get_name()]
 
-    def __wrapped_default(self) -> Any:
+    def _wrapped_default(self) -> Any:
         if self.get_name() not in self.__default:
             if callable(self._default):
                 default = self._default(self.__input_value_map)

--- a/src/zrb/task_input/base_input.py
+++ b/src/zrb/task_input/base_input.py
@@ -10,7 +10,8 @@ logger.debug(colored("Loading zrb.task_input.base_input", attrs=["dark"]))
 
 # flake8: noqa E501
 
-InputCallback = Callable[[Mapping[str, Any]], Any]
+InputCallback = Callable[[Mapping[str, Any], Any], Any]
+InputDefault = Callable[[Mapping[str, Any]], Any]
 
 
 @typechecked
@@ -60,7 +61,7 @@ class BaseInput(AnyInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
@@ -143,7 +144,7 @@ class BaseInput(AnyInput):
     def _wrapped_callback(self, ctx, param, value) -> Any:
         if self.get_name() not in self.__input_value_map:
             if callable(self._callback):
-                result = self._callback(self.__input_value_map)
+                result = self._callback(self.__input_value_map, value)
                 self.__input_value_map[self.get_name()] = result
                 return result
             self.__input_value_map[self.get_name()] = value

--- a/src/zrb/task_input/base_input.py
+++ b/src/zrb/task_input/base_input.py
@@ -137,19 +137,19 @@ class BaseInput(AnyInput):
         return options
     
     def __wrapped_callback(self, ctx, param, value) -> Any:
-        if self.name not in self.__input_value_map:
-            self.__input_value_map[self.name] = value
-        return self.__input_value_map[self.name]
+        if self.get_name() not in self.__input_value_map:
+            self.__input_value_map[self.get_name()] = value
+        return self.__input_value_map[self.get_name()]
     
     def __wrapped_default(self) -> Any:
-        if self.name not in self.__default:
+        if self.get_name() not in self.__default:
             if callable(self._default):
                 default = self._default(self.__input_value_map)
-                self.__default[self.name] = default
+                self.__default[self.get_name()] = default
                 return default
-            self.__default[self.name] = self._default
+            self.__default[self.get_name()] = self._default
             return self._default
-        return self.__default[self.name]
+        return self.__default[self.get_name()]
 
     def should_render(self) -> bool:
         return self.__should_render

--- a/src/zrb/task_input/bool_input.py
+++ b/src/zrb/task_input/bool_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.bool_input", attrs=["dark"]))
 
@@ -49,7 +49,8 @@ class BoolInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -72,6 +73,7 @@ class BoolInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/bool_input.py
+++ b/src/zrb/task_input/bool_input.py
@@ -20,9 +20,10 @@ class BoolInput(BaseInput):
     Args:
         name (str): The name of the input.
         shortcut (Optional[str]): A shortcut string for the input.
-        default (Optional[Any]): The default value for the input. Should be a boolean if set.
-        description (Optional[str]): A brief description of the input.
-        show_default (Union[bool, str, None]): Option to display the default value. Can be a boolean or string representation.
+        default (Optional[Any]): The default value of the input.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
         confirmation_prompt (Union[bool, str]): If set to `True`, the user is asked to confirm the input.
         prompt_required (bool): If `True`, the prompt for input is mandatory.

--- a/src/zrb/task_input/bool_input.py
+++ b/src/zrb/task_input/bool_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.bool_input", attrs=["dark"]))
 
@@ -49,7 +49,7 @@ class BoolInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/choice_input.py
+++ b/src/zrb/task_input/choice_input.py
@@ -25,8 +25,9 @@ class ChoiceInput(BaseInput):
         shortcut (Optional[str]): An optional shortcut string for the input.
         choices (Iterable[Any]): An iterable of choices from which the user can select.
         default (Optional[Any]): The default value for the input. Should be one of the choices if set.
-        description (Optional[str]): A brief description of the input.
-        show_default (Union[bool, str, None]): Option to display the default value. Can be a boolean or string representation.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
         confirmation_prompt (Union[bool, str]): If set to `True`, the user is asked to confirm the input.
         prompt_required (bool): If `True`, the prompt for input is mandatory.

--- a/src/zrb/task_input/choice_input.py
+++ b/src/zrb/task_input/choice_input.py
@@ -4,7 +4,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Iterable, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.choice_input", attrs=["dark"]))
 
@@ -54,7 +54,8 @@ class ChoiceInput(BaseInput):
         name: str,
         shortcut: Optional[str] = None,
         choices: Iterable[Any] = [],
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -77,6 +78,7 @@ class ChoiceInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/choice_input.py
+++ b/src/zrb/task_input/choice_input.py
@@ -4,7 +4,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Iterable, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.choice_input", attrs=["dark"]))
 
@@ -54,7 +54,7 @@ class ChoiceInput(BaseInput):
         name: str,
         shortcut: Optional[str] = None,
         choices: Iterable[Any] = [],
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/float_input.py
+++ b/src/zrb/task_input/float_input.py
@@ -21,8 +21,9 @@ class FloatInput(BaseInput):
         name (str): The name of the input.
         shortcut (Optional[str]): An optional shortcut string for the input.
         default (Optional[Any]): The default value for the input, expected to be a float if set.
-        description (Optional[str]): A brief description of the input's purpose.
-        show_default (Union[bool, str, None]): Option to display the default value. Can be a boolean or string.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
         confirmation_prompt (Union[bool, str]): If `True`, the user is asked to confirm the input.
         prompt_required (bool): If `True`, the prompt for input is mandatory.

--- a/src/zrb/task_input/float_input.py
+++ b/src/zrb/task_input/float_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.float_input", attrs=["dark"]))
 
@@ -49,7 +49,7 @@ class FloatInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/float_input.py
+++ b/src/zrb/task_input/float_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.float_input", attrs=["dark"]))
 
@@ -49,7 +49,8 @@ class FloatInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -72,6 +73,7 @@ class FloatInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/int_input.py
+++ b/src/zrb/task_input/int_input.py
@@ -22,8 +22,9 @@ class IntInput(BaseInput):
         name (str): The name of the input, serving as an identifier.
         shortcut (Optional[str]): An optional shortcut for easier reference to the input.
         default (Optional[Any]): The default value for the input, should be an integer if provided.
-        description (Optional[str]): A brief description of what the input represents or its intended use.
-        show_default (Union[bool, str, None]): Option to show the default value in prompts or documentation.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to determine the prompt for user input. If `True`, uses a default prompt.
         confirmation_prompt (Union[bool, str]): If `True`, the user will be asked to confirm their input.
         prompt_required (bool): If `True`, makes the input prompt mandatory.

--- a/src/zrb/task_input/int_input.py
+++ b/src/zrb/task_input/int_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.int_input", attrs=["dark"]))
 
@@ -50,7 +50,7 @@ class IntInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/int_input.py
+++ b/src/zrb/task_input/int_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.int_input", attrs=["dark"]))
 
@@ -50,7 +50,8 @@ class IntInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -73,6 +74,7 @@ class IntInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/multiline_input.py
+++ b/src/zrb/task_input/multiline_input.py
@@ -47,14 +47,15 @@ class MultilineInput(BaseInput):
         >>> multiline_input.get_default()
         'user123'
     """
+
     __default: Mapping[str, Any] = {}
 
     def __init__(
         self,
         name: str,
         shortcut: Optional[str] = None,
-        comment_start = "#",
-        editor = default_editor,
+        comment_start="#",
+        editor=default_editor,
         default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
@@ -106,5 +107,7 @@ class MultilineInput(BaseInput):
             text = super()._wrapped_default()
             prompt = self._prompt if isinstance(self._prompt, str) else self.get_name()
             mark_comment = " ".join([self._comment_start, prompt])
-            self.__default[self.get_name()] = edit(editor=self._editor, mark_comment=mark_comment, text=text)
+            self.__default[self.get_name()] = edit(
+                editor=self._editor, mark_comment=mark_comment, text=text
+            )
         return self.__default[self.get_name()]

--- a/src/zrb/task_input/multiline_input.py
+++ b/src/zrb/task_input/multiline_input.py
@@ -1,0 +1,110 @@
+from zrb.config.config import default_editor
+from zrb.helper.accessories.color import colored
+from zrb.helper.log import logger
+from zrb.helper.multilline import edit
+from zrb.helper.typecheck import typechecked
+from zrb.helper.typing import Any, Mapping, Optional, Union
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
+
+logger.debug(colored("Loading zrb.task_input.multiline_input", attrs=["dark"]))
+
+# flake8: noqa E501
+
+
+@typechecked
+class MultilineInput(BaseInput):
+    """
+    A specialized input class for handling string-based inputs in various tasks.
+
+    `StrInput` extends `BaseInput` to manage string-type inputs, supporting features like
+    default values, prompts, flags, and other customization options. This class is useful
+    for tasks requiring textual input, such as names, descriptions, or any other string parameters.
+
+    Args:
+        name (str): The name of the input, used as an identifier.
+        shortcut (Optional[str]): An optional shortcut string for the input.
+        default (Optional[Any]): The default value for the input, expected to be a string if set.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
+        prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
+        confirmation_prompt (Union[bool, str]): If `True`, the user is asked to confirm the input.
+        prompt_required (bool): If `True’, the prompt for input is mandatory.
+        hide_input (bool): If `True’, hides the input value, typically used for sensitive data.
+        is_flag (Optional[bool]): Indicates if the input is a flag. If `True’, the input accepts boolean flag values.
+        flag_value (Optional[Any]): The value associated with the flag if `is_flag` is `True`.
+        multiple (bool): If `True’, allows multiple string values for the input.
+        count (bool): If `True’, counts the occurrences of the input.
+        allow_from_autoenv (bool): If `True’, enables automatic population of the input from environment variables.
+        hidden (bool): If `True’, keeps the input hidden in help messages or documentation.
+        show_choices (bool): If `True’, shows any restricted choices for the input value.
+        show_envvar (bool): If `True’, displays the associated environment variable, if applicable.
+        nargs (int): The number of arguments that the input can accept.
+        should_render (bool): If `True’, renders the input in the user interface or command-line interface.
+
+    Examples:
+        >>> multiline_input = StrInput(name='username', default='user123', description='Enter your username')
+        >>> multiline_input.get_default()
+        'user123'
+    """
+    __default: Mapping[str, Any] = {}
+
+    def __init__(
+        self,
+        name: str,
+        shortcut: Optional[str] = None,
+        comment_start = "#",
+        editor = default_editor,
+        default: Optional[Union[Any, InputDefault]] = None,
+        callback: Optional[InputCallback] = None,
+        description: Optional[str] = None,
+        show_default: Union[bool, str, None] = None,
+        prompt: Union[bool, str] = True,
+        confirmation_prompt: Union[bool, str] = False,
+        prompt_required: bool = True,
+        hide_input: bool = False,
+        is_flag: Optional[bool] = None,
+        flag_value: Optional[Any] = None,
+        multiple: bool = False,
+        count: bool = False,
+        allow_from_autoenv: bool = True,
+        hidden: bool = False,
+        show_choices: bool = True,
+        show_envvar: bool = False,
+        nargs: int = 1,
+        should_render: bool = True,
+    ):
+        BaseInput.__init__(
+            self,
+            name=name,
+            shortcut=shortcut,
+            default=default,
+            callback=callback,
+            description=description,
+            show_default=show_default,
+            prompt=prompt,
+            confirmation_prompt=confirmation_prompt,
+            prompt_required=prompt_required,
+            hide_input=hide_input,
+            is_flag=is_flag,
+            flag_value=flag_value,
+            multiple=multiple,
+            count=count,
+            allow_from_autoenv=allow_from_autoenv,
+            type=str,
+            hidden=hidden,
+            show_choices=show_choices,
+            show_envvar=show_envvar,
+            nargs=nargs,
+            should_render=should_render,
+        )
+        self._comment_start = comment_start
+        self._editor = editor
+
+    def _wrapped_default(self) -> Any:
+        if self.get_name() not in self.__default:
+            text = super()._wrapped_default()
+            prompt = self._prompt if isinstance(self._prompt, str) else self.get_name()
+            mark_comment = " ".join([self._comment_start, prompt])
+            self.__default[self.get_name()] = edit(editor=self._editor, mark_comment=mark_comment, text=text)
+        return self.__default[self.get_name()]

--- a/src/zrb/task_input/password_input.py
+++ b/src/zrb/task_input/password_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.password_input", attrs=["dark"]))
 
@@ -50,7 +50,7 @@ class PasswordInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/password_input.py
+++ b/src/zrb/task_input/password_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.password_input", attrs=["dark"]))
 
@@ -50,7 +50,8 @@ class PasswordInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -72,6 +73,7 @@ class PasswordInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/password_input.py
+++ b/src/zrb/task_input/password_input.py
@@ -23,8 +23,9 @@ class PasswordInput(BaseInput):
         name (str): The name of the input, serving as an identifier.
         shortcut (Optional[str]): An optional shortcut string for the input.
         default (Optional[Any]): The default value for the input, expected to be a string if set.
-        description (Optional[str]): A brief description of the input's purpose.
-        show_default (Union[bool, str, None]): Option to display the default value. Can be a boolean or string.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
         confirmation_prompt (Union[bool, str]): If `True`, the user is asked to confirm the input.
         prompt_required (bool): If `True`, the prompt for input is mandatory.

--- a/src/zrb/task_input/str_input.py
+++ b/src/zrb/task_input/str_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.str_input", attrs=["dark"]))
 
@@ -50,7 +50,7 @@ class StrInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Union[Any, InputCallback]] = None,
+        default: Optional[Union[Any, InputDefault]] = None,
         callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,

--- a/src/zrb/task_input/str_input.py
+++ b/src/zrb/task_input/str_input.py
@@ -2,7 +2,7 @@ from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
 from zrb.helper.typecheck import typechecked
 from zrb.helper.typing import Any, Optional, Union
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.str_input", attrs=["dark"]))
 
@@ -50,7 +50,8 @@ class StrInput(BaseInput):
         self,
         name: str,
         shortcut: Optional[str] = None,
-        default: Optional[Any] = None,
+        default: Optional[Union[Any, InputCallback]] = None,
+        callback: Optional[InputCallback] = None,
         description: Optional[str] = None,
         show_default: Union[bool, str, None] = None,
         prompt: Union[bool, str] = True,
@@ -73,6 +74,7 @@ class StrInput(BaseInput):
             name=name,
             shortcut=shortcut,
             default=default,
+            callback=callback,
             description=description,
             show_default=show_default,
             prompt=prompt,

--- a/src/zrb/task_input/str_input.py
+++ b/src/zrb/task_input/str_input.py
@@ -22,8 +22,9 @@ class StrInput(BaseInput):
         name (str): The name of the input, used as an identifier.
         shortcut (Optional[str]): An optional shortcut string for the input.
         default (Optional[Any]): The default value for the input, expected to be a string if set.
-        description (Optional[str]): A brief description of the input's purpose.
-        show_default (Union[bool, str, None]): Option to display the default value. Can be a boolean or string.
+        callback (Optional[Any]): The default value of the input.
+        description (Optional[str]): A brief description of what the input is for.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): A boolean or string to prompt the user for input. If `True`, uses the default prompt.
         confirmation_prompt (Union[bool, str]): If `True`, the user is asked to confirm the input.
         prompt_required (bool): If `True’, the prompt for input is mandatory.

--- a/src/zrb/task_input/task_input.py
+++ b/src/zrb/task_input/task_input.py
@@ -1,6 +1,6 @@
 from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
-from zrb.task_input.base_input import BaseInput
+from zrb.task_input.base_input import BaseInput, InputCallback
 
 logger.debug(colored("Loading zrb.task_input.task_input", attrs=["dark"]))
 

--- a/src/zrb/task_input/task_input.py
+++ b/src/zrb/task_input/task_input.py
@@ -15,8 +15,9 @@ class Input(BaseInput):
         name (str): The name of the input, used as a unique identifier.
         shortcut (Optional[str]): An optional single-character shortcut for the input.
         default (Optional[Any]): The default value of the input.
+        callback (Optional[Any]): The default value of the input.
         description (Optional[str]): A brief description of what the input is for.
-        show_default (Union[bool, JinjaTemplate, None]): Determines whether the default value should be displayed.
+        show_default (Union[bool, JinjaTemplate, None]): Determines the default value to be shown.
         prompt (Union[bool, str]): The prompt text to be displayed when asking for the input.
         confirmation_prompt (Union[bool, str]): A prompt for confirmation if required.
         prompt_required (bool): Indicates whether a prompt is required.

--- a/src/zrb/task_input/task_input.py
+++ b/src/zrb/task_input/task_input.py
@@ -1,6 +1,6 @@
 from zrb.helper.accessories.color import colored
 from zrb.helper.log import logger
-from zrb.task_input.base_input import BaseInput, InputCallback
+from zrb.task_input.base_input import BaseInput, InputCallback, InputDefault
 
 logger.debug(colored("Loading zrb.task_input.task_input", attrs=["dark"]))
 

--- a/zrb_init.py
+++ b/zrb_init.py
@@ -28,6 +28,7 @@ from zrb import (
     ChoiceInput,
     FloatInput,
     IntInput,
+    MultilineInput,
     PasswordInput,
     StrInput,
 )
@@ -182,6 +183,7 @@ def make_docs(*args: Any, **kwargs: Any):
         os.path.join(dir, "task-inputs", "choice-input.md"): ChoiceInput,
         os.path.join(dir, "task-inputs", "float-input.md"): FloatInput,
         os.path.join(dir, "task-inputs", "int-input.md"): IntInput,
+        os.path.join(dir, "task-inputs", "multiline-input.md"): MultilineInput,
         os.path.join(dir, "task-inputs", "password-input.md"): PasswordInput,
         os.path.join(dir, "task-inputs", "str-input.md"): StrInput,
     }


### PR DESCRIPTION
# Summary

Make it possible to do this:

```python
import click
from zrb import runner, CmdTask, StrInput

coba = CmdTask(
    name="coba",
    inputs=[
        StrInput(name="a", default="alpha"),
        StrInput(name="also-a", default=lambda input_map: input_map.get("a")),
        StrInput(name="buffer", default=lambda input_map: click.edit(text="ora umum", editor="hx"))
    ],
    cmd=[
        "echo a {{input.a}}",
        "echo also_a {{input.also_a}}",
        "echo 'buffer {{input.buffer}}'",
    ]
)
runner.register(coba)
```

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review

# Ticket or Issue

> Ticket or issue number if applicable.

# How to Test

> How to test that this PR works.