### PR TITLE
Make openai and pydantic more lazy-loaded

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 🔖 [Documentation Home](../README.md) > Changelog
 
+# 1.5.13
+
+- Add note to task execution error for better traceability
+- Implement lazy load for all pydantic ai and openai dependency
+
 # 1.5.12
 
 - Introduce `append_tool` and `append_mcp_server` to `LLMTask`

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -29,4 +29,15 @@ docker login -U stalchmst
 zrb publish all
 ```
 
+# Inspecting Import Performance
+
+To inspect import peformance, you can run the following command:
+
+```bash
+pip install benchmark-imports
+python -m benchmark_imports zrb
+```
+
+You can use the result to decide whether a module/dependency should be lazy-loaded or not.
+
 🔖 [Documentation Home](../README.md)

--- a/src/zrb/llm_config.py
+++ b/src/zrb/llm_config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pydantic_ai.models import Model
@@ -139,6 +139,7 @@ class LLMConfig:
         if self._default_model_base_url is None and self._default_model_api_key is None:
             return "openai"
         from pydantic_ai.providers.openai import OpenAIProvider
+
         return OpenAIProvider(
             base_url=self._default_model_base_url, api_key=self._default_model_api_key
         )
@@ -183,6 +184,7 @@ class LLMConfig:
         if model_name is None:
             return None
         from pydantic_ai.models.openai import OpenAIModel
+
         return OpenAIModel(
             model_name=model_name,
             provider=self.get_default_model_provider(),

--- a/src/zrb/llm_config.py
+++ b/src/zrb/llm_config.py
@@ -1,9 +1,12 @@
 import os
+from typing import Any, TYPE_CHECKING
 
-from pydantic_ai.models import Model
-from pydantic_ai.models.openai import OpenAIModel
-from pydantic_ai.providers import Provider
-from pydantic_ai.providers.openai import OpenAIProvider
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+    from pydantic_ai.providers import Provider
+else:
+    Model = Any
+    Provider = Any
 
 from zrb.util.string.conversion import to_boolean
 
@@ -135,6 +138,7 @@ class LLMConfig:
             return self._default_provider
         if self._default_model_base_url is None and self._default_model_api_key is None:
             return "openai"
+        from pydantic_ai.providers.openai import OpenAIProvider
         return OpenAIProvider(
             base_url=self._default_model_base_url, api_key=self._default_model_api_key
         )
@@ -178,6 +182,7 @@ class LLMConfig:
         model_name = self._get_model_name()
         if model_name is None:
             return None
+        from pydantic_ai.models.openai import OpenAIModel
         return OpenAIModel(
             model_name=model_name,
             provider=self.get_default_model_provider(),

--- a/src/zrb/task/llm/agent.py
+++ b/src/zrb/task/llm/agent.py
@@ -1,12 +1,11 @@
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openai import APIError
     from pydantic_ai import Agent, Tool
     from pydantic_ai.agent import AgentRun
     from pydantic_ai.mcp import MCPServer
-    from pydantic_ai.messages import ModelMessagesTypeAdapter
     from pydantic_ai.models import Model
     from pydantic_ai.settings import ModelSettings
 else:
@@ -43,6 +42,8 @@ def create_agent_instance(
 ) -> Agent:
     """Creates a new Agent instance with configured tools and servers."""
     # Get tools
+    from pydantic_ai import Agent, Tool
+
     tools_or_callables = list(tools_attr(ctx) if callable(tools_attr) else tools_attr)
     tools_or_callables.extend(additional_tools)
     tools = []
@@ -82,6 +83,8 @@ def get_agent(
     additional_mcp_servers: list[MCPServer],
 ) -> Agent:
     """Retrieves the configured Agent instance or creates one if necessary."""
+    from pydantic_ai import Agent
+
     if isinstance(agent_attr, Agent):
         return agent_attr
     if callable(agent_attr):
@@ -127,6 +130,8 @@ async def run_agent_iteration(
     Raises:
         Exception: If any error occurs during agent execution.
     """
+    from pydantic_ai.messages import ModelMessagesTypeAdapter
+
     async with agent.run_mcp_servers():
         async with agent.iter(
             user_prompt=user_prompt,

--- a/src/zrb/task/llm/agent.py
+++ b/src/zrb/task/llm/agent.py
@@ -1,12 +1,23 @@
 from collections.abc import Callable
+from typing import Any, TYPE_CHECKING
 
-from openai import APIError
-from pydantic_ai import Agent, Tool
-from pydantic_ai.agent import AgentRun
-from pydantic_ai.mcp import MCPServer
-from pydantic_ai.messages import ModelMessagesTypeAdapter
-from pydantic_ai.models import Model
-from pydantic_ai.settings import ModelSettings
+if TYPE_CHECKING:
+    from openai import APIError
+    from pydantic_ai import Agent, Tool
+    from pydantic_ai.agent import AgentRun
+    from pydantic_ai.mcp import MCPServer
+    from pydantic_ai.messages import ModelMessagesTypeAdapter
+    from pydantic_ai.models import Model
+    from pydantic_ai.settings import ModelSettings
+else:
+    APIError = Any
+    Agent = Any
+    Tool = Any
+    AgentRun = Any
+    MCPServer = Any
+    ModelMessagesTypeAdapter = Any
+    Model = Any
+    ModelSettings = Any
 
 from zrb.context.any_context import AnyContext
 from zrb.context.any_shared_context import AnySharedContext

--- a/src/zrb/task/llm/config.py
+++ b/src/zrb/task/llm/config.py
@@ -1,7 +1,11 @@
-from typing import Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-from pydantic_ai.models import Model
-from pydantic_ai.settings import ModelSettings
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+    from pydantic_ai.settings import ModelSettings
+else:
+    Model = Any
+    ModelSettings = Any
 
 from zrb.attr.type import StrAttr, fstring
 from zrb.context.any_context import AnyContext
@@ -59,6 +63,8 @@ def get_model(
     render_model_api_key: bool,
 ) -> str | Model | None:
     """Gets the model instance or name, handling defaults and configuration."""
+    from pydantic_ai.models import Model
+
     model = get_attr(ctx, model_attr, None, auto_render=render_model)
     if model is None:
         return default_llm_config.get_default_model()

--- a/src/zrb/task/llm/context_enrichment.py
+++ b/src/zrb/task/llm/context_enrichment.py
@@ -1,12 +1,9 @@
 import json
 import traceback
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
-from pydantic_ai import Agent
-from pydantic_ai.models import Model
-from pydantic_ai.settings import ModelSettings
 
 from zrb.attr.type import BoolAttr, IntAttr
 from zrb.context.any_context import AnyContext
@@ -14,6 +11,15 @@ from zrb.llm_config import llm_config
 from zrb.task.llm.agent import run_agent_iteration
 from zrb.task.llm.typing import ListOfDict
 from zrb.util.attr import get_bool_attr, get_int_attr
+
+if TYPE_CHECKING:
+    from pydantic_ai import Agent
+    from pydantic_ai.models import Model
+    from pydantic_ai.settings import ModelSettings
+else:
+    Agent = Any
+    Model = Any
+    ModelSettings = Any
 
 
 class EnrichmentConfig(BaseModel):

--- a/src/zrb/task/llm/error.py
+++ b/src/zrb/task/llm/error.py
@@ -1,8 +1,12 @@
 import json
-from typing import Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from openai import APIError
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from openai import APIError
+else:
+    APIError = Any
 
 
 # Define a structured error model for tool execution failures

--- a/src/zrb/task/llm/error.py
+++ b/src/zrb/task/llm/error.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel
 

--- a/src/zrb/task/llm/history_summarization.py
+++ b/src/zrb/task/llm/history_summarization.py
@@ -1,10 +1,7 @@
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
-from pydantic_ai import Agent
-from pydantic_ai.models import Model
-from pydantic_ai.settings import ModelSettings
 
 from zrb.attr.type import BoolAttr, IntAttr
 from zrb.context.any_context import AnyContext
@@ -12,6 +9,13 @@ from zrb.llm_config import llm_config
 from zrb.task.llm.agent import run_agent_iteration
 from zrb.task.llm.typing import ListOfDict
 from zrb.util.attr import get_bool_attr, get_int_attr
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+    from pydantic_ai.settings import ModelSettings
+else:
+    Model = Any
+    ModelSettings = Any
 
 
 def get_history_part_len(history_list: ListOfDict) -> int:
@@ -90,6 +94,8 @@ async def summarize_history(
     history_list: ListOfDict,
 ) -> dict[str, Any]:
     """Runs an LLM call to summarize history and update the context."""
+    from pydantic_ai import Agent
+
     ctx.log_info("Attempting to summarize conversation history...")
 
     summarization_agent = Agent(

--- a/src/zrb/task/llm/print_node.py
+++ b/src/zrb/task/llm/print_node.py
@@ -1,22 +1,21 @@
 from collections.abc import Callable
 from typing import Any
 
-from pydantic_ai import Agent
-from pydantic_ai.messages import (
-    FinalResultEvent,
-    FunctionToolCallEvent,
-    FunctionToolResultEvent,
-    PartDeltaEvent,
-    PartStartEvent,
-    TextPartDelta,
-    ToolCallPartDelta,
-)
-
 from zrb.util.cli.style import stylize_faint
 
 
 async def print_node(print_func: Callable, agent_run: Any, node: Any):
     """Prints the details of an agent execution node using a provided print function."""
+    from pydantic_ai import Agent
+    from pydantic_ai.messages import (
+        FinalResultEvent,
+        FunctionToolCallEvent,
+        FunctionToolResultEvent,
+        PartDeltaEvent,
+        PartStartEvent,
+        TextPartDelta,
+        ToolCallPartDelta,
+    )
     if Agent.is_user_prompt_node(node):
         # A user prompt node => The user has provided input
         print_func(stylize_faint(f">> UserPromptNode: {node.user_prompt}"))

--- a/src/zrb/task/llm/print_node.py
+++ b/src/zrb/task/llm/print_node.py
@@ -16,6 +16,7 @@ async def print_node(print_func: Callable, agent_run: Any, node: Any):
         TextPartDelta,
         ToolCallPartDelta,
     )
+
     if Agent.is_user_prompt_node(node):
         # A user prompt node => The user has provided input
         print_func(stylize_faint(f">> UserPromptNode: {node.user_prompt}"))

--- a/src/zrb/task/llm/tool_wrapper.py
+++ b/src/zrb/task/llm/tool_wrapper.py
@@ -3,12 +3,17 @@ import inspect
 import traceback
 import typing
 from collections.abc import Callable
-
-from pydantic_ai import RunContext, Tool
+from typing import Any, TYPE_CHECKING
 
 from zrb.context.any_context import AnyContext
 from zrb.task.llm.error import ToolExecutionError
 from zrb.util.run import run_async
+
+if TYPE_CHECKING:
+    # from pydantic_ai import RunContext, Tool
+    from pydantic_ai import Tool
+else:
+    Tool = Any
 
 
 def wrap_tool(func: Callable, ctx: AnyContext) -> Tool:
@@ -123,6 +128,7 @@ def _adjust_signature(
     # (we inject it). So, the wrapper's signature should be the original signature,
     # minus any parameters annotated with RunContext or AnyContext.
 
+    from pydantic_ai import RunContext
     params_for_schema = [
         param
         for param in original_sig.parameters.values()

--- a/src/zrb/task/llm/tool_wrapper.py
+++ b/src/zrb/task/llm/tool_wrapper.py
@@ -3,14 +3,13 @@ import inspect
 import traceback
 import typing
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from zrb.context.any_context import AnyContext
 from zrb.task.llm.error import ToolExecutionError
 from zrb.util.run import run_async
 
 if TYPE_CHECKING:
-    # from pydantic_ai import RunContext, Tool
     from pydantic_ai import Tool
 else:
     Tool = Any
@@ -18,6 +17,8 @@ else:
 
 def wrap_tool(func: Callable, ctx: AnyContext) -> Tool:
     """Wraps a tool function to handle exceptions and context propagation."""
+    from pydantic_ai import RunContext, Tool
+
     original_sig = inspect.signature(func)
     # Use helper function for clarity
     needs_run_context_for_pydantic = _has_context_parameter(original_sig, RunContext)
@@ -129,6 +130,7 @@ def _adjust_signature(
     # minus any parameters annotated with RunContext or AnyContext.
 
     from pydantic_ai import RunContext
+
     params_for_schema = [
         param
         for param in original_sig.parameters.values()

--- a/src/zrb/task/llm_task.py
+++ b/src/zrb/task/llm_task.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pydantic_ai import Agent, Tool
@@ -90,7 +90,8 @@ class LLMTask(BaseTask):
         context_enrichment_threshold: IntAttr | None = None,
         render_context_enrichment_threshold: bool = True,
         tools: (
-            list["ToolOrCallable"] | Callable[[AnySharedContext], list["ToolOrCallable"]]
+            list["ToolOrCallable"]
+            | Callable[[AnySharedContext], list["ToolOrCallable"]]
         ) = [],
         mcp_servers: (
             list["MCPServer"] | Callable[[AnySharedContext], list["MCPServer"]]

--- a/src/zrb/task/llm_task.py
+++ b/src/zrb/task/llm_task.py
@@ -1,11 +1,18 @@
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-from pydantic_ai import Agent, Tool
-from pydantic_ai.mcp import MCPServer
-from pydantic_ai.models import Model
-from pydantic_ai.settings import ModelSettings
+if TYPE_CHECKING:
+    from pydantic_ai import Agent, Tool
+    from pydantic_ai.mcp import MCPServer
+    from pydantic_ai.models import Model
+    from pydantic_ai.settings import ModelSettings
+else:
+    Agent = Any
+    Tool = Any
+    MCPServer = Any
+    Model = Any
+    ModelSettings = Any
 
 from zrb.attr.type import BoolAttr, IntAttr, StrAttr, fstring
 from zrb.context.any_context import AnyContext
@@ -39,7 +46,10 @@ from zrb.task.llm.prompt import (
 from zrb.util.cli.style import stylize_faint
 from zrb.xcom.xcom import Xcom
 
-ToolOrCallable = Tool | Callable
+if TYPE_CHECKING:
+    ToolOrCallable = Tool | Callable
+else:
+    ToolOrCallable = Any
 
 
 class LLMTask(BaseTask):
@@ -80,10 +90,10 @@ class LLMTask(BaseTask):
         context_enrichment_threshold: IntAttr | None = None,
         render_context_enrichment_threshold: bool = True,
         tools: (
-            list[ToolOrCallable] | Callable[[AnySharedContext], list[ToolOrCallable]]
+            list["ToolOrCallable"] | Callable[[AnySharedContext], list["ToolOrCallable"]]
         ) = [],
         mcp_servers: (
-            list[MCPServer] | Callable[[AnySharedContext], list[MCPServer]]
+            list["MCPServer"] | Callable[[AnySharedContext], list["MCPServer"]]
         ) = [],
         conversation_history: (
             ConversationHistoryData
@@ -166,9 +176,9 @@ class LLMTask(BaseTask):
         self._context_enrichment_threshold = context_enrichment_threshold
         self._render_context_enrichment_threshold = render_context_enrichment_threshold
         self._tools = tools
-        self._additional_tools: list[ToolOrCallable] = []
+        self._additional_tools: list["ToolOrCallable"] = []
         self._mcp_servers = mcp_servers
-        self._additional_mcp_servers: list[MCPServer] = []
+        self._additional_mcp_servers: list["MCPServer"] = []
         self._conversation_history = conversation_history
         self._conversation_history_reader = conversation_history_reader
         self._conversation_history_writer = conversation_history_writer


### PR DESCRIPTION
# Summary

Implement lazy load for `pydantic-ai` and `openai` dependencies. Those dependencies are taking some times to load, but not always needed.

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review

# Ticket or Issue
https://github.com/state-alchemists/zrb/issues/204


# How to Test

```
python -m benchmark_imports zrb
```

```
0.6412 root       zrb
0.4397 project    zrb.builtin
0.1232 project    zrb.callback.callback
0.1221 project    zrb.session.any_session
0.1196 project    zrb.session_state_log.session_state_log
0.0616 project    zrb.builtin.todo
0.0543 dependency pydantic
0.0493 project    zrb.builtin.setup.asdf.asdf
0.0482 transitive pydantic._migration                      from pydantic
0.0480 transitive pydantic.version                         from pydantic._migration
0.0479 transitive pydantic_core                            from pydantic.version
0.0441 transitive pydantic_core.core_schema                from pydantic_core
0.0439 project    zrb.builtin.setup.latex.ubuntu
0.0439 project    zrb.builtin.git
0.0380 project    zrb.runner.cli
0.0349 project    zrb.builtin.setup.zsh.zsh
0.0330 project    zrb.builtin.setup.ubuntu
0.0298 dependency pydantic.main
0.0291 project    zrb.builtin.project.add.fastapp.fastapp_task
0.0272 project    zrb.builtin.setup.tmux.tmux
0.0272 project    zrb.builtin.git_subtree
0.0253 transitive asyncio                                  from pydantic_core.core_schema
0.0222 transitive asyncio.base_events                      from asyncio
0.0221 project    zrb.builtin.base64
0.0188 transitive pydantic._internal._model_construction   from pydantic.main
```