### PR TITLE
Fix long line output

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 🔖 [Documentation Home](../README.md) > Changelog
 
+# 1.6.2
+
+- Handle long lines of CmdTask output
+
 # 1.6.1
 
 - Fix LLMTask summarization and context enrichment mechanism

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zrb"
-version = "1.6.1"
+version = "1.6.2"
 description = "Your Automation Powerhouse"
 authors = ["Go Frendi Gunawan <gofrendiasgard@gmail.com>"]
 license = "AGPL-3.0-or-later"

--- a/src/zrb/util/cmd/command.py
+++ b/src/zrb/util/cmd/command.py
@@ -64,11 +64,25 @@ async def run_command(
         stream, print_method: Callable[..., None], max_lines: int
     ) -> str:
         lines = []
+        if hasattr(stream, "_limit"):
+            stream._limit = 1024 * 1024 * 10
         while True:
-            line = await stream.readline()
+            line = None
+            try:
+                line = await stream.readline()
+            except asyncio.exceptions.LimitOverrunError as e:
+                # Recover by reading a limited chunk instead
+                await stream.read(e.consumed)
+                line = b"<output line too long>"
+            except BaseException as e:
+                line = f"Error while reading stream {type(e)} {e}"
+                pass
             if not line:
                 break
-            line = line.decode("utf-8").rstrip()
+            try:
+                line = line.decode("utf-8").rstrip()
+            except Exception:
+                pass
             lines.append(line)
             if len(lines) > max_lines:
                 lines.pop(0)  # Keep only the last max_lines

--- a/src/zrb/util/cmd/command.py
+++ b/src/zrb/util/cmd/command.py
@@ -72,6 +72,8 @@ async def run_command(
             try:
                 line = await stream.readline()
                 line = line.decode("utf-8").rstrip()
+            except asyncio.exceptions.CancelledError:
+                break
             except asyncio.exceptions.LimitOverrunError as e:
                 # Recover by reading a limited chunk instead
                 await stream.read(e.consumed)

--- a/src/zrb/util/cmd/command.py
+++ b/src/zrb/util/cmd/command.py
@@ -65,24 +65,22 @@ async def run_command(
     ) -> str:
         lines = []
         if hasattr(stream, "_limit"):
+            # The limit is set to 10 MB
             stream._limit = 1024 * 1024 * 10
         while True:
             line = None
             try:
                 line = await stream.readline()
+                line = line.decode("utf-8").rstrip()
             except asyncio.exceptions.LimitOverrunError as e:
                 # Recover by reading a limited chunk instead
                 await stream.read(e.consumed)
-                line = b"<output line too long>"
+                line = "<output line too long>"
             except BaseException as e:
                 line = f"Error while reading stream {type(e)} {e}"
                 pass
             if not line:
                 break
-            try:
-                line = line.decode("utf-8").rstrip()
-            except Exception:
-                pass
             lines.append(line)
             if len(lines) > max_lines:
                 lines.pop(0)  # Keep only the last max_lines


### PR DESCRIPTION
# Summary

Fixing long line output

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review

# Ticket or Issue

```
2025-05-14 04:57:37 ERROR: Task exception was never retrieved
future: <Task finished name='Task-11' coro=<run_command.<locals>.__read_stream() done, defined at /home/gofrendi/.local-venv/lib/python3.10/site-packages/zrb/util/cmd/command.py:63> exception=ValueError('Separator is found, but chunk is longer than limit')>
Traceback (most recent call last):
  File "/home/gofrendi/.pyenv/versions/3.10.0/lib/python3.10/asyncio/streams.py", line 525, in readline
    line = await self.readuntil(sep)
  File "/home/gofrendi/.pyenv/versions/3.10.0/lib/python3.10/asyncio/streams.py", line 620, in readuntil
    raise exceptions.LimitOverrunError(
asyncio.exceptions.LimitOverrunError: Separator is found, but chunk is longer than limit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gofrendi/.local-venv/lib/python3.10/site-packages/zrb/util/cmd/command.py", line 68, in __read_stream
    line = await stream.readline()
  File "/home/gofrendi/.pyenv/versions/3.10.0/lib/python3.10/asyncio/streams.py", line 534, in readline
    raise ValueError(e.args[0])
ValueError: Separator is found, but chunk is longer than limit
```

# How to Test

Run a CmdTask that print a very long text (more than 1 MB)