### PR TITLE
Fix logging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 🔖 [Documentation Home](../README.md) > Changelog
 
+# 1.6.9
+
+- Bug fix: plain logging not added to shared log
+
 # 1.6.8
 
 - Rename `set_default_provider` to `set_default_model_provider` on `LLMConfig`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zrb"
-version = "1.6.8"
+version = "1.6.9"
 description = "Your Automation Powerhouse"
 authors = ["Go Frendi Gunawan <gofrendiasgard@gmail.com>"]
 license = "AGPL-3.0-or-later"

--- a/src/zrb/context/context.py
+++ b/src/zrb/context/context.py
@@ -107,6 +107,7 @@ class Context(AnyContext):
         if plain:
             # self.append_to_shared_log(remove_style(message))
             print(message, sep=sep, end=end, file=file, flush=flush)
+            self.append_to_shared_log(remove_style(f"{message}{end}"))
             return
         color = self._color
         icon = self._icon
@@ -120,7 +121,7 @@ class Context(AnyContext):
         now = datetime.datetime.now()
         formatted_time = now.strftime("%y%m%d %H:%M:%S.%f")[:19] + " "
         prefix = f"{formatted_time}{attempt_status} {padded_styled_task_name} ⬤ "
-        self.append_to_shared_log(remove_style(f"{prefix} {message}"))
+        self.append_to_shared_log(remove_style(f"{prefix} {message}{end}"))
         stylized_prefix = stylize(prefix, color=color)
         print(f"{stylized_prefix} {message}", sep=sep, end=end, file=file, flush=flush)
 

--- a/src/zrb/runner/web_route/static/resources/session/current-session.js
+++ b/src/zrb/runner/web_route/static/resources/session/current-session.js
@@ -25,7 +25,7 @@ const CURRENT_SESSION = {
                 resultTextarea.rows = resultLineCount <= 5 ? resultLineCount : 5;
                 // update text areas
                 resultTextarea.value = data.final_result;
-                logTextarea.value = data.log.join("\n");
+                logTextarea.value = data.log.join("");
                 // logTextarea.scrollTop = logTextarea.scrollHeight;
                 // visualize history
                 this.showCurrentSession(data.task_status, data.finished);


### PR DESCRIPTION
# Summary

Bug fixing: missing log from web interface, especially on `LLMTask` instances.

Cause:

Session state logger is not being called when performing `ctx.print` with `plain` parameter activated (i.e., `ctx.print(..., plain=True)`)

Solution:

- Call session state logger whenever `ctx.print` is called.
- Attach the line ending at the end of the message.

Drawbacks and Mitigation:

- The existing logs might not have line endings in the web interface. This problem can probably be solved at the frontend by joining logs using "\n" only if logs doesn't have line ending
- Or just absorb the drawback, since the log itself is available on the files

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review

# Ticket or Issue

> Ticket or issue number if applicable.

# How to Test

- Run `zrb llm ask "Hi, how are you" --start-new
- Run `zrb server start`
- Visit `http://localhost:21213`, look for session history