### PR TITLE
Improve skill prompt

### DIFF
--- a/docs/advanced-topics/claude-compatibility.md
+++ b/docs/advanced-topics/claude-compatibility.md
@@ -60,6 +60,35 @@ Detailed instructions for the LLM on how to perform this skill.
 | `description` | Brief description |
 | `user-invocable` | If `true`, becomes slash command in TUI |
 
+### Companion Files
+
+When a skill lives in its own dedicated directory with a `SKILL.md` or `SKILL.py`
+entry point, other files in that directory (scripts, templates, configs, reference
+docs) are **auto-discovered** and surfaced to the LLM on activation. This allows
+skill authors to bundle helper tooling alongside instructions.
+
+**Convention:** `SKILL.md` / `SKILL.py` in a subdirectory enables companion
+discovery. Flat `*.skill.md` files shared across a directory do not — they
+share the namespace with other skills and companions aren't unambiguous.
+
+Example directory structure:
+
+```
+.zrb/skills/
+└── my-deploy-skill/
+    ├── SKILL.md
+    ├── scripts/
+    │   ├── deploy.sh
+    │   └── rollback.sh
+    └── deploy-config.yaml
+```
+
+When the skill is activated (via `/my-deploy-skill` or `ActivateSkill`), the LLM
+sees the companion file listing and can read or use them during execution.
+
+The `ActivateSkill` tool also returns the skill directory path and companion
+file listing alongside the skill content.
+
 ---
 
 ## 3. Agents and Subagents (AGENT.md)

--- a/src/zrb/llm/custom_command/custom_command.py
+++ b/src/zrb/llm/custom_command/custom_command.py
@@ -58,9 +58,11 @@ class CustomCommand(AnyCustomCommand):
             prompt,
         )
 
-        # If no replacement occurred and the original prompt has no placeholders,
-        # append the arguments.
-        if prompt == self._prompt and "$" not in self._prompt:
+        # If no replacement occurred, append the arguments so the LLM
+        # sees the user's input. Don't check for "$" in the content —
+        # skills may contain dollar signs (regex patterns, shell examples,
+        # etc.) without having actual placeholder variables.
+        if prompt == self._prompt:
             args_info = (
                 kwargs.get("ARGUMENTS", "")
                 if len(self.args) == 1 and self.args[0] == "ARGUMENTS"

--- a/src/zrb/llm/custom_command/skill_command_factory.py
+++ b/src/zrb/llm/custom_command/skill_command_factory.py
@@ -1,8 +1,10 @@
 import re
 from collections.abc import Callable
+from pathlib import Path
 
 from zrb.llm.custom_command.any_custom_command import AnyCustomCommand
 from zrb.llm.custom_command.custom_command import CustomCommand
+from zrb.llm.skill._util import format_companion_file_lines
 from zrb.llm.skill.manager import SkillManager
 
 
@@ -30,10 +32,22 @@ def _get_skill_custom_commands(skill_manager: SkillManager) -> list[AnyCustomCom
         description = skill.description
         if skill.argument_hint:
             description = f"{skill.description} {skill.argument_hint}"
+        # Prepend skill context header (directory path + companion files)
+        skill_dir = str(Path(skill.path).parent)
+        context_lines = [
+            f"Skill directory (working directory): {skill_dir}",
+            "",
+            "All file paths in the instructions below are relative to this directory.",
+            "Use companion files (scripts, tools, references) by resolving them against this path.",
+        ]
+        context_lines.extend(format_companion_file_lines(skill.companion_files))
+        context_lines.append("")
+        context_lines.append("---")
+        prompt_with_companions = "\n".join(context_lines) + "\n\n" + content
         commands.append(
             CustomCommand(
                 command=f"/{skill.name}",
-                prompt=content,
+                prompt=prompt_with_companions,
                 args=args,
                 description=description,
             )

--- a/src/zrb/llm/skill/_util.py
+++ b/src/zrb/llm/skill/_util.py
@@ -1,0 +1,57 @@
+"""Internal utilities for the skill package.
+
+Holds companion-file discovery and formatting logic shared across
+manager.py, tool/skill.py, and skill_command_factory.py.
+"""
+
+from pathlib import Path
+
+
+def discover_companion_files(skill_path: str) -> list[str]:
+    """Discover companion files recursively for dedicated-directory skills.
+
+    Only applies when the skill file is named exactly SKILL.md or SKILL.py,
+    meaning it has a dedicated directory. Flat ``*.skill.md`` files share
+    a directory with other skills so companions are not reported for them.
+    """
+    skill_file = Path(skill_path)
+    if skill_file.name not in ("SKILL.md", "SKILL.py"):
+        return []
+    skill_dir = skill_file.parent
+    if not skill_dir.is_dir():
+        return []
+    return sorted(
+        str(f.relative_to(skill_dir))
+        for f in skill_dir.rglob("*")
+        if f.is_file() and f.name not in ("SKILL.md", "SKILL.py")
+    )
+
+
+def format_companion_file_lines(companion_files: list[str]) -> list[str]:
+    """Format companion file paths into human-readable lines grouped by directory.
+
+    Returns lines ready to be appended to a header block (e.g. ``context_lines``
+    or ``header_lines``). Each line is a plain string without trailing newline.
+
+    Returns an empty list when *companion_files* is empty.
+    """
+    if not companion_files:
+        return []
+    groups: dict[str, list[str]] = {}
+    standalone: list[str] = []
+    for f in companion_files:
+        parts = f.split("/")
+        if len(parts) > 1:
+            group = parts[0]
+            groups.setdefault(group, []).append(f)
+        else:
+            standalone.append(f)
+    lines = [""]
+    lines.append("Companion files available in this directory:")
+    for f in sorted(standalone):
+        lines.append(f"  {f}")
+    for group in sorted(groups):
+        lines.append(f"  {group}/")
+        for f in sorted(groups[group]):
+            lines.append(f"    {f.split('/', 1)[1]}")
+    return lines

--- a/src/zrb/llm/skill/manager.py
+++ b/src/zrb/llm/skill/manager.py
@@ -7,6 +7,7 @@ import yaml
 
 from zrb.config.config import CFG
 from zrb.llm.hook.manager import hook_manager
+from zrb.llm.skill._util import discover_companion_files
 from zrb.util.load import load_module_from_path
 
 _IGNORE_DIRS = [
@@ -52,6 +53,7 @@ class Skill:
         agent: str | None = None,
         content: str | None = None,
         content_factory: Callable[[], str] | None = None,
+        companion_files: list[str] | None = None,
     ):
         self.name = name
         self.path = path
@@ -65,6 +67,7 @@ class Skill:
         self.agent = agent
         self.content = content
         self.content_factory = content_factory
+        self.companion_files = companion_files or []
 
 
 class SkillManager:
@@ -282,11 +285,13 @@ class SkillManager:
                 skill_obj = getattr(module, "SKILL")
 
             if isinstance(skill_obj, Skill):
+                skill_obj.companion_files = discover_companion_files(full_path)
                 self._skills[skill_obj.name] = skill_obj
             elif hasattr(module, "get_skill") and callable(module.get_skill):
                 # Factory function that returns a Skill
                 skill_obj = module.get_skill()
                 if isinstance(skill_obj, Skill):
+                    skill_obj.companion_files = discover_companion_files(full_path)
                     self._skills[skill_obj.name] = skill_obj
 
         except Exception as e:
@@ -387,6 +392,7 @@ class SkillManager:
                 context=context,
                 agent=agent,
                 content=content,  # Persist content to avoid re-reading
+                companion_files=discover_companion_files(full_path),
             )
         except Exception as e:
             CFG.LOGGER.warning(f"Failed to load Markdown skill from {full_path}: {e}")

--- a/src/zrb/llm/tool/skill.py
+++ b/src/zrb/llm/tool/skill.py
@@ -1,27 +1,8 @@
 from pathlib import Path
 
+from zrb.llm.skill._util import discover_companion_files, format_companion_file_lines
 from zrb.llm.skill.manager import SkillManager
 from zrb.llm.skill.manager import skill_manager as default_skill_manager
-
-
-def _get_companion_files(skill_path: str) -> list[str]:
-    """Return companion files for skills that live in their own directory.
-
-    Only applies when the skill file is named exactly SKILL.md or SKILL.py,
-    meaning it has a dedicated directory. Flat *.skill.md files share a directory
-    with other skills so companions are not reported for them.
-    """
-    skill_file = Path(skill_path)
-    if skill_file.name not in ("SKILL.md", "SKILL.py"):
-        return []
-    skill_dir = skill_file.parent
-    if not skill_dir.is_dir():
-        return []
-    return sorted(
-        str(f)
-        for f in skill_dir.iterdir()
-        if f.is_file() and f.name not in ("SKILL.md", "SKILL.py")
-    )
 
 
 def create_activate_skill_tool(skill_manager: SkillManager | None = None):
@@ -42,15 +23,19 @@ def create_activate_skill_tool(skill_manager: SkillManager | None = None):
             return f"Skill '{name}' not found."
 
         skill_dir = str(Path(skill.path).parent)
-        companion_files = _get_companion_files(skill.path)
+        companion_files = skill.companion_files or discover_companion_files(skill.path)
 
-        header_lines = [f"Skill directory: {skill_dir}"]
-        if companion_files:
-            header_lines.append("Companion files:")
-            for f in companion_files:
-                header_lines.append(f"  - {f}")
-        else:
-            header_lines.append("Companion files: none")
+        header_lines = [
+            "Skill activated. The following context applies:",
+            "",
+            f"Skill directory (working directory): {skill_dir}",
+            "",
+            "All file paths in the skill instructions below are relative to this directory.",
+            "Use companion files (scripts, tools, references) by resolving them against this path.",
+        ]
+        header_lines.extend(format_companion_file_lines(companion_files))
+        header_lines.append("")
+        header_lines.append("---")
 
         header = "\n".join(header_lines)
         return f"<ACTIVATED_SKILL>\n{header}\n\n{content}\n</ACTIVATED_SKILL>"

--- a/test/llm/custom_command/test_custom_command.py
+++ b/test/llm/custom_command/test_custom_command.py
@@ -237,6 +237,25 @@ class TestCustomCommandEdgeCases:
         result = cmd.get_prompt({"file": "/path/to/file with spaces.txt"})
         assert "/path/to/file with spaces.txt" in result
 
+    def test_get_prompt_literal_dollar_not_placeholder(self):
+        """Prompt with literal $ (regex, prices, shell vars) still appends args.
+
+        Regression guard: the old code had a ``"$" not in self._prompt`` guard
+        that suppressed arguments when the prompt contained any dollar sign,
+        even if none were actual placeholders (e.g. regex like ``\\d+$``).
+        """
+        cmd = CustomCommand(
+            command="test",
+            prompt="Match end of line: \\d+$",
+            args=["ARGUMENTS"],
+        )
+
+        result = cmd.get_prompt({"ARGUMENTS": "hello"})
+
+        # The prompt should preserve the literal $ and append the argument
+        assert "\\d+$" in result
+        assert "ARGUMENTS: hello" in result
+
 
 class TestCustomCommandArgOrder:
     """Test argument ordering in CustomCommand."""

--- a/test/llm/custom_command/test_skill_command_factory.py
+++ b/test/llm/custom_command/test_skill_command_factory.py
@@ -54,8 +54,10 @@ class TestGetSkillCustomCommand:
         skill = MagicMock(spec=Skill)
         skill.user_invocable = True
         skill.name = "my_skill"
+        skill.path = "/some/path/SKILL.md"
         skill.description = "A test skill"
         skill.argument_hint = None
+        skill.companion_files = []
         mock_manager.scan.return_value = [skill]
         mock_manager.get_skill_content.return_value = (
             "This is skill content with $ARGUMENTS"
@@ -75,8 +77,10 @@ class TestGetSkillCustomCommand:
         skill = MagicMock(spec=Skill)
         skill.user_invocable = True
         skill.name = "test"
+        skill.path = "/some/path/SKILL.md"
         skill.description = "Test"
         skill.argument_hint = "<file>"
+        skill.companion_files = []
         mock_manager.scan.return_value = [skill]
         mock_manager.get_skill_content.return_value = "Content"
 
@@ -85,3 +89,31 @@ class TestGetSkillCustomCommand:
 
         assert len(result) == 1
         assert "<file>" in result[0].description
+
+    def test_get_skill_custom_command_with_companion_files(self):
+        """Test companion files are included in the prompt."""
+        mock_manager = MagicMock()
+        skill = MagicMock(spec=Skill)
+        skill.user_invocable = True
+        skill.name = "my_skill"
+        skill.path = "/some/path/SKILL.md"
+        skill.description = "A test skill"
+        skill.argument_hint = None
+        skill.companion_files = ["README.md", "scripts/run.sh"]
+        mock_manager.scan.return_value = [skill]
+        mock_manager.get_skill_content.return_value = "Skill content"
+
+        factory = get_skill_custom_command(mock_manager)
+        result = factory()
+
+        assert len(result) == 1
+        prompt = result[0].get_prompt({})
+        # Header elements
+        assert "Skill directory" in prompt
+        assert "Companion files available in this directory:" in prompt
+        assert "  README.md" in prompt
+        assert "  scripts/" in prompt
+        assert "    run.sh" in prompt
+        assert "---" in prompt
+        # Original content preserved
+        assert "Skill content" in prompt

--- a/test/llm/skill/test__util.py
+++ b/test/llm/skill/test__util.py
@@ -1,0 +1,89 @@
+"""Tests for llm/skill/_util.py - Shared skill utilities."""
+
+import tempfile
+from pathlib import Path
+
+from zrb.llm.skill._util import discover_companion_files, format_companion_file_lines
+
+
+class TestDiscoverCompanionFiles:
+    """Tests for discover_companion_files."""
+
+    def test_returns_empty_for_flat_skill_file(self):
+        """Flat *.skill.md files have no dedicated directory."""
+        result = discover_companion_files("/some/path/my-skill.skill.md")
+        assert result == []
+
+    def test_returns_companions_for_skilL_md(self):
+        """SKILL.md in a dedicated directory discovers sibling files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp)
+            skill_file = skill_dir / "SKILL.md"
+            skill_file.write_text("# Test")
+            # Create companion files
+            (skill_dir / "README.md").write_text("readme")
+            (skill_dir / "scripts").mkdir()
+            (skill_dir / "scripts" / "run.sh").write_text("run")
+            (skill_dir / "data.txt").write_text("data")
+
+            result = discover_companion_files(str(skill_file))
+
+            assert "README.md" in result
+            assert "scripts/run.sh" in result
+            assert "data.txt" in result
+            assert "SKILL.md" not in result  # Self excluded
+
+    def test_returns_companions_for_skilL_py(self):
+        """SKILL.py in a dedicated directory discovers sibling files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp)
+            skill_file = skill_dir / "SKILL.py"
+            skill_file.write_text("# python")
+            (skill_dir / "helper.py").write_text("helper")
+
+            result = discover_companion_files(str(skill_file))
+
+            assert "helper.py" in result
+            assert "SKILL.py" not in result
+
+    def test_returns_empty_when_directory_missing(self):
+        """Non-existent path returns empty list."""
+        result = discover_companion_files("/nonexistent/SKILL.md")
+        assert result == []
+
+
+class TestFormatCompanionFileLines:
+    """Tests for format_companion_file_lines."""
+
+    def test_empty_list(self):
+        """Empty input returns empty list."""
+        assert format_companion_file_lines([]) == []
+
+    def test_standalone_files_only(self):
+        """Files without directory prefix are listed flat."""
+        result = format_companion_file_lines(["README.md", "data.txt"])
+        assert result[0] == ""
+        assert "Companion files available in this directory:" in result[1]
+        assert "  data.txt" in result
+        assert "  README.md" in result
+
+    def test_grouped_files(self):
+        """Files with directory prefix are grouped under their top-level dir."""
+        result = format_companion_file_lines(
+            ["scripts/setup.sh", "scripts/run.sh", "config/app.yaml"]
+        )
+        assert "  scripts/" in result
+        assert "    setup.sh" in result
+        assert "    run.sh" in result
+        assert "  config/" in result
+        assert "    app.yaml" in result
+
+    def test_mixed_files(self):
+        """Standalone and grouped files are both rendered."""
+        result = format_companion_file_lines(
+            ["README.md", "scripts/run.sh", "data.json"]
+        )
+        assert "  README.md" in result
+        assert "  data.json" in result
+        assert "  scripts/" in result
+        assert "    run.sh" in result

--- a/test/llm/tool/test_skill.py
+++ b/test/llm/tool/test_skill.py
@@ -18,6 +18,7 @@ class TestCreateActivateSkillTool:
         mock_skill.name = "test-skill"
         mock_skill.path = "/test/SKILL.md"
         mock_skill.model_invocable = True
+        mock_skill.companion_files = []
 
         mock_manager = MagicMock(spec=SkillManager)
         mock_manager.get_skill.return_value = mock_skill
@@ -54,12 +55,50 @@ class TestCreateActivateSkillTool:
         from zrb.llm.tool.skill import create_activate_skill_tool
 
         with patch("zrb.llm.tool.skill.default_skill_manager") as mock_default_manager:
-            mock_default_manager.get_skill.return_value = MagicMock()
-            # We need to return an invocable skill
-            mock_default_manager.get_skill.return_value.model_invocable = True
+            mock_skill = MagicMock()
+            mock_skill.model_invocable = True
+            mock_skill.companion_files = []
+            mock_default_manager.get_skill.return_value = mock_skill
             mock_default_manager.get_skill_content.return_value = "content"
 
             func = create_activate_skill_tool()  # No skill_manager provided
             await func(name="test")
 
             mock_default_manager.get_skill.assert_called_once_with("test")
+
+    @pytest.mark.asyncio
+    async def test_activate_skill_with_companion_files(self):
+        """Test companion files appear in activation output with grouping."""
+        from zrb.llm.skill.manager import SkillManager
+        from zrb.llm.tool.skill import create_activate_skill_tool
+
+        mock_skill = MagicMock()
+        mock_skill.name = "test-skill"
+        mock_skill.path = "/test/SKILL.md"
+        mock_skill.model_invocable = True
+        mock_skill.companion_files = [
+            "README.md",
+            "scripts/setup.sh",
+            "scripts/run.sh",
+            "config/default.yaml",
+        ]
+
+        mock_manager = MagicMock(spec=SkillManager)
+        mock_manager.get_skill.return_value = mock_skill
+        mock_manager.get_skill_content.return_value = "content"
+
+        func = create_activate_skill_tool(skill_manager=mock_manager)
+        result = await func(name="test-skill")
+
+        # Check header elements
+        assert "Skill directory (working directory): /test" in result
+        assert "Companion files available in this directory:" in result
+        # Standalone file
+        assert "  README.md" in result
+        # Grouped files
+        assert "  scripts/" in result
+        assert "    setup.sh" in result
+        assert "    run.sh" in result
+        assert "  config/" in result
+        assert "    default.yaml" in result
+        assert "---" in result


### PR DESCRIPTION
# Summary

Improve skill prompt, allow `/skill <prompt>` even if skill has no arguments and contain `$`

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review