### PR TITLE
Make slash command works for message as parameter in interactive mode

### DIFF
--- a/src/zrb/llm/task/chat/runner_mixin.py
+++ b/src/zrb/llm/task/chat/runner_mixin.py
@@ -94,7 +94,7 @@ class RunnerMixin:
         initial_attachments: "list[UserContent]",
     ) -> Any:
         # Resolve custom commands and intercept if the message is a slash command
-        resolved_custom_commands = resolve_custom_commands(self._custom_commands)
+        resolved_custom_commands = self._resolve_custom_commands()
         effective_message = initial_message
         if isinstance(initial_message, str):
             resolved = resolve_custom_command(initial_message, resolved_custom_commands)
@@ -140,6 +140,15 @@ class RunnerMixin:
         # lazy: zrb internal (heavy via transitive / circular)
         from zrb.llm.ui.base.ui import BaseUI
 
+        # Mirror _run_non_interactive_session's slash-command resolution.
+        # Resolved once here and reused by _build_default_ui_kwargs below,
+        # instead of re-resolving self._custom_commands a second time.
+        resolved_custom_commands = self._resolve_custom_commands()
+        if isinstance(initial_message, str):
+            resolved = resolve_custom_command(initial_message, resolved_custom_commands)
+            if resolved is not None:
+                initial_message = resolved
+
         # Note: AsyncExitStack is handled by LLMTask._exec_action
         # 1. Resolve UIs from factories
         resolved_uis: list["UIProtocol"] = list(self._uis)
@@ -171,6 +180,7 @@ class RunnerMixin:
             initial_attachments=initial_attachments,
             enable_rewind=enable_rewind,
             snapshot_dir=snapshot_dir,
+            resolved_custom_commands=resolved_custom_commands,
         )
 
         # 3. Determine the UI to use
@@ -206,13 +216,15 @@ class RunnerMixin:
         initial_attachments: "list[UserContent]",
         enable_rewind: bool = False,
         snapshot_dir: str = "",
+        resolved_custom_commands: "list[AnyCustomCommand] | None" = None,
     ) -> dict[str, Any]:
         """Build keyword arguments shared by all default UI constructor calls."""
         resolved_custom_model_names = get_attr(ctx, self._custom_model_names, []) or []
         if not isinstance(resolved_custom_model_names, list):
             resolved_custom_model_names = []
 
-        resolved_custom_commands = self._resolve_custom_commands()
+        if resolved_custom_commands is None:
+            resolved_custom_commands = self._resolve_custom_commands()
 
         effective_show_ollama_models = (
             CFG.LLM_SHOW_OLLAMA_MODELS

--- a/test/llm/task/chat/test_runner_mixin.py
+++ b/test/llm/task/chat/test_runner_mixin.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -184,6 +183,123 @@ async def test_run_interactive_session_with_factories_and_multiplex(runner):
 
         # When only one UI is resolved from factories, MultiUI is NOT used
         assert res == "Final"
+
+
+class FakeCustomCommand:
+    """Duck-typed stand-in for AnyCustomCommand used to test slash-command
+    resolution without depending on a concrete implementation."""
+
+    def __init__(self, command: str, args: list[str], prompt_template: str):
+        self.command = command
+        self.description = "fake command"
+        self.args = args
+        self._prompt_template = prompt_template
+
+    def get_prompt(self, kwargs: dict[str, str]) -> str:
+        return self._prompt_template.format(**kwargs)
+
+
+UI_COMMAND_KEYS = [
+    "summarize",
+    "attach",
+    "exit",
+    "info",
+    "save",
+    "load",
+    "rewind",
+    "yolo_toggle",
+    "set_model",
+    "redirect_output",
+    "exec",
+    "btw",
+    "plan",
+    "copy",
+    "voice",
+    "build",
+]
+
+
+@pytest.fixture
+def ui_commands():
+    return {k: [] for k in UI_COMMAND_KEYS}
+
+
+@pytest.mark.asyncio
+async def test_run_interactive_session_resolves_custom_command_initial_message(
+    runner, ui_commands
+):
+    """A slash-command initial_message must be resolved to its prompt before
+    reaching the UI, mirroring _run_non_interactive_session's behavior."""
+    runner._custom_commands = [
+        FakeCustomCommand(
+            command="/foo", args=["text"], prompt_template="RESOLVED:{text}"
+        )
+    ]
+
+    ctx = MagicMock()
+    ctx.xcom = {}
+
+    llm_task_core = MagicMock()
+    history_manager = MagicMock()
+    history_manager.load.return_value = []
+
+    mock_ui = SimpleMockUI()
+
+    with patch("zrb.llm.ui.default.ui.UI") as MockUI:
+        MockUI.return_value = mock_ui
+
+        res = await runner._run_interactive_session(
+            ctx=ctx,
+            llm_task_core=llm_task_core,
+            history_manager=history_manager,
+            ui_commands=ui_commands,
+            initial_message="/foo bar",
+            initial_conversation_name="sess1",
+            initial_yolo=False,
+            initial_attachments=[],
+        )
+
+        assert res == "Final"
+        assert MockUI.call_args.kwargs["initial_message"] == "RESOLVED:bar"
+
+
+@pytest.mark.asyncio
+async def test_run_interactive_session_leaves_plain_message_unchanged(
+    runner, ui_commands
+):
+    """A plain (non-slash-command) initial_message must pass through as-is,
+    even when custom commands are registered."""
+    runner._custom_commands = [
+        FakeCustomCommand(
+            command="/foo", args=["text"], prompt_template="RESOLVED:{text}"
+        )
+    ]
+
+    ctx = MagicMock()
+    ctx.xcom = {}
+
+    llm_task_core = MagicMock()
+    history_manager = MagicMock()
+    history_manager.load.return_value = []
+
+    mock_ui = SimpleMockUI()
+
+    with patch("zrb.llm.ui.default.ui.UI") as MockUI:
+        MockUI.return_value = mock_ui
+
+        res = await runner._run_interactive_session(
+            ctx=ctx,
+            llm_task_core=llm_task_core,
+            history_manager=history_manager,
+            ui_commands=ui_commands,
+            initial_message="hello there",
+            initial_conversation_name="sess1",
+            initial_yolo=False,
+            initial_attachments=[],
+        )
+
+        assert res == "Final"
+        assert MockUI.call_args.kwargs["initial_message"] == "hello there"
 
 
 def test_load_session_history_uses_replay_when_available(runner):


### PR DESCRIPTION
# Summary

Make slash command works for message as parameter in interactive mode

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review