### PR TITLE
Fix markdown width and responsiveness

### DIFF
--- a/src/zrb/llm/agent/common.py
+++ b/src/zrb/llm/agent/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import inspect
 import json
@@ -116,7 +117,7 @@ def _truncated_content(content: str) -> tuple[str, dict[str, Any]]:
 def create_safe_wrapper(func: Callable, name: str | None = None) -> Callable:
     """Create a wrapper that catches exceptions and returns ToolReturn objects."""
     # lazy: heavy third-party
-    from pydantic_ai import ToolReturn
+    from pydantic_ai import ModelRetry, ToolReturn
 
     # lazy: circular — permission is a leaf module; capability is read at wrap
     # time (cheap) so the per-call gate need not re-import it.
@@ -138,7 +139,12 @@ def create_safe_wrapper(func: Callable, name: str | None = None) -> Callable:
             if inspect.iscoroutinefunction(func):
                 result = await func(*args, **kwargs)
             else:
-                result = func(*args, **kwargs)
+                # This wrapper is a coroutine function, so pydantic-ai never
+                # applies its own executor offload for sync tools — inline they
+                # would block the TUI's event loop for the tool's duration
+                # (ReadFile on a big file, grep, journal search). ContextVars
+                # propagate into the thread; none of the sync tools write them.
+                result = await asyncio.to_thread(func, *args, **kwargs)
 
             # If result is already a ToolReturn, return it as-is. The tool framed
             # its own content (possibly truncated deliberately) — respect it.
@@ -154,6 +160,11 @@ def create_safe_wrapper(func: Callable, name: str | None = None) -> Callable:
             return ToolReturn(
                 return_value=safe_result, content=content, metadata=metadata
             )
+        except ModelRetry:
+            # pydantic-ai's retry protocol: the framework turns this into a
+            # retry prompt for the model. Swallowing it into an error string
+            # would disable retries for every tool.
+            raise
         except Exception as e:
             error_msg = f"Error executing tool {func.__name__}: {e}"
             return ToolReturn(
@@ -166,7 +177,7 @@ def create_safe_wrapper(func: Callable, name: str | None = None) -> Callable:
 def _wrap_toolset(toolset: "AbstractToolset[None]") -> "AbstractToolset[None]":
     """Wrap a toolset with error handling."""
     # lazy: heavy third-party
-    from pydantic_ai import ToolReturn
+    from pydantic_ai import ModelRetry, ToolReturn
     from pydantic_ai.toolsets import WrapperToolset
 
     # lazy: circular — permission is a leaf module.
@@ -200,6 +211,10 @@ def _wrap_toolset(toolset: "AbstractToolset[None]") -> "AbstractToolset[None]":
                     metadata=metadata,
                 )
                 return await _fire_post_tool_use(name, tool_args, wrapped)
+            except ModelRetry:
+                # Part of pydantic-ai's retry protocol — must reach the
+                # framework, not become an opaque error string.
+                raise
             except Exception as e:
                 await _fire_post_tool_use_failure(name, tool_args, e)
                 error_msg = f"Error executing tool {name}: {e}"

--- a/src/zrb/llm/history_manager/file_history_manager.py
+++ b/src/zrb/llm/history_manager/file_history_manager.py
@@ -423,14 +423,22 @@ class FileHistoryManager(AnyHistoryManager):
     def _save_data_to_file(self, file_path: str, data: Any) -> bool:
         """Save filtered data to a file.
 
-        Returns True if successful, False otherwise.
+        Returns True if successful, False otherwise. Writes to a sibling temp
+        file and renames into place — truncate-writing the live conversation
+        file directly means a crash mid-write corrupts the whole history.
         """
+        tmp_path = f"{file_path}.tmp"
         try:
-            with open(file_path, "w", encoding="utf-8") as f:
+            with open(tmp_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
+            os.replace(tmp_path, file_path)
             return True
         except OSError as e:
             zrb_print(f"Error: Failed to save history to {file_path}: {e}", plain=True)
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
             return False
 
     def _rotate_backups(

--- a/src/zrb/llm/prompt/live_context.py
+++ b/src/zrb/llm/prompt/live_context.py
@@ -32,6 +32,7 @@ prompt assembly to ambient runtime state:
    runs the tool short-circuits with a ``[SYSTEM SUGGESTION]`` instead.
 """
 
+import asyncio
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -217,15 +218,48 @@ def render_live_context(
 
     The ``model`` argument is accepted for parity with ``system_context`` but is
     not currently rendered here (the model identity line is a stable fact).
+
+    On the async per-turn hot path, prefer ``render_live_context_async`` — this
+    sync form blocks its caller for the duration of the git subprocesses.
+    """
+    # lazy: zrb internal (heavy via transitive / circular)
+    from zrb.llm.tool.plan import todo_manager
+
+    session_name, interactive_bool = _wire_ambient_state(ctx)
+    git_lines, todos_data = _collect_git_info(todo_manager, session_name)
+    return _render_parts(git_lines, todos_data, interactive_bool, inject_journal_index)
+
+
+async def render_live_context_async(
+    ctx: AnyContext, model: "Any" = None, inject_journal_index: bool = False
+) -> str:
+    """``render_live_context`` for async callers (the per-turn hot path).
+
+    The ContextVar wiring runs on the event loop (writes must land in the
+    caller's context); only the git subprocesses + todo fetch are offloaded —
+    inline they freeze the TUI at the start of every turn for as long as
+    ``git status`` takes (routinely hundreds of ms on WSL2 / large repos).
+    """
+    # lazy: zrb internal (heavy via transitive / circular)
+    from zrb.llm.tool.plan import todo_manager
+
+    session_name, interactive_bool = _wire_ambient_state(ctx)
+    git_lines, todos_data = await asyncio.to_thread(
+        _collect_git_info, todo_manager, session_name
+    )
+    return _render_parts(git_lines, todos_data, interactive_bool, inject_journal_index)
+
+
+def _wire_ambient_state(ctx: AnyContext) -> tuple[str, bool]:
+    """Per-turn ContextVar wiring (must run on the caller's thread/context).
+
+    Returns ``(session_name, interactive_bool)``.
     """
     # lazy: zrb internal (heavy via transitive / circular)
     from zrb.llm.tool.ambient_state import (
-        get_active_worktree,
-        set_active_worktree,
         set_current_tool_session,
         set_interactive_mode,
     )
-    from zrb.llm.tool.plan import todo_manager
 
     try:
         session_name = str(ctx.input.session) if hasattr(ctx, "input") else ""
@@ -239,9 +273,18 @@ def render_live_context(
     except Exception:
         interactive_bool = True
     set_interactive_mode(interactive_bool)
+    return session_name, interactive_bool
 
-    # --- Dynamic: git and todos ---
-    git_lines, todos_data = _collect_git_info(todo_manager, session_name)
+
+def _render_parts(
+    git_lines: list[str],
+    todos_data: "dict[str, Any] | None",
+    interactive_bool: bool,
+    inject_journal_index: bool,
+) -> str:
+    """Assemble the live-context lines (ContextVar reads stay on the caller)."""
+    # lazy: zrb internal (heavy via transitive / circular)
+    from zrb.llm.tool.ambient_state import get_active_worktree, set_active_worktree
 
     # --- Worktree (ContextVar — must run on caller's thread) ---
     active_wt = get_active_worktree()

--- a/src/zrb/llm/prompt/manager.py
+++ b/src/zrb/llm/prompt/manager.py
@@ -266,6 +266,27 @@ class PromptManager:
             inject_journal_index and "journal_mandate" in self.active_sections
         )
         body = render_live_context(ctx, self._model, inject_journal_index=inject_index)
+        return self._finish_live_context(body, ctx)
+
+    async def create_live_context_async(
+        self, ctx: AnyContext, inject_journal_index: bool = False
+    ) -> str:
+        """``create_live_context`` for async callers (the per-turn hot path):
+        the git subprocesses run off-loop instead of blocking the event loop.
+        """
+        # lazy: keep the async twin's import local, mirroring the sync path.
+        from zrb.llm.prompt.live_context import render_live_context_async
+
+        inject_index = (
+            inject_journal_index and "journal_mandate" in self.active_sections
+        )
+        body = await render_live_context_async(
+            ctx, self._model, inject_journal_index=inject_index
+        )
+        return self._finish_live_context(body, ctx)
+
+    def _finish_live_context(self, body: str, ctx: AnyContext) -> str:
+        """Append registered live-context providers and wrap the block."""
         for name, provider in self._live_context_providers:
             try:
                 extra = provider(ctx)

--- a/src/zrb/llm/task/builder_mixin.py
+++ b/src/zrb/llm/task/builder_mixin.py
@@ -297,6 +297,17 @@ class BuilderMixin:
             ctx, inject_journal_index=inject_journal_index
         )
 
+    async def get_live_context_async(
+        self, ctx: AnyContext, inject_journal_index: bool = False
+    ) -> str:
+        """``get_live_context`` for async callers: git collection runs off-loop
+        so the per-turn render cannot freeze the TUI's event loop."""
+        if self._prompt_manager is None:
+            return ""
+        return await self._prompt_manager.create_live_context_async(
+            ctx, inject_journal_index=inject_journal_index
+        )
+
     def _get_model_settings(self, ctx: AnyContext) -> ModelSettings | None:
         model_settings = self._model_settings
         rendered_model_settings = get_attr(ctx, model_settings, None)

--- a/src/zrb/llm/task/llm_task.py
+++ b/src/zrb/llm/task/llm_task.py
@@ -259,7 +259,11 @@ class LLMTask(BuilderMixin, HistoryMixin, BaseTask):  # type: ignore[reportIncom
     ) -> Any:
         conversation_name = self._get_conversation_name(ctx)
         history_manager = self._get_history_manager(ctx)
-        message_history = history_manager.load(conversation_name)
+        # Offload: load deserializes + re-validates the whole conversation —
+        # O(history) blocking work that would stall the TUI's event loop.
+        message_history = await asyncio.to_thread(
+            history_manager.load, conversation_name
+        )
         user_message = cast(str, get_attr(ctx, self._message, "", self._render_message))
         user_attachments = get_attachments(ctx, self._attachment)
 
@@ -284,7 +288,7 @@ class LLMTask(BuilderMixin, HistoryMixin, BaseTask):  # type: ignore[reportIncom
         # index snapshot is seeded on the first turn only (empty history); each
         # later summarization re-seeds it at its own site (summarize_history), so
         # the index is always present without living in the cached system prompt.
-        live_context = self.get_live_context(
+        live_context = await self.get_live_context_async(
             ctx, inject_journal_index=not message_history
         )
         agent = self._create_agent(ctx, system_prompt=system_prompt, toolsets=toolsets)
@@ -349,7 +353,10 @@ class LLMTask(BuilderMixin, HistoryMixin, BaseTask):  # type: ignore[reportIncom
             raise e
 
         history_manager.update(conversation_name, new_history)
-        history_manager.save(conversation_name)
+        # Offload: save serializes, re-validates, and writes the whole
+        # conversation (twice, with the backup) — it lands at the exact moment
+        # the user expects the prompt back, so it must not block the loop.
+        await asyncio.to_thread(history_manager.save, conversation_name)
         ctx.log_debug(f"All messages: {new_history}")
 
         return self._post_process_output(output)

--- a/src/zrb/llm/tool/code.py
+++ b/src/zrb/llm/tool/code.py
@@ -324,30 +324,22 @@ async def _extract_info(
         # Handle LSP context format vs raw content
         if "lsp_symbols" in metadata:
             # LSP semantic context (more compact)
-            content = json.dumps(
-                {
-                    "path": path,
-                    "symbols": metadata.get("lsp_symbols", []),
-                    "diagnostics": metadata.get("lsp_diagnostics", []),
-                    "note": "LSP semantic context - symbol names, types, and locations",
-                }
-            )
+            payload = {
+                "path": path,
+                "symbols": metadata.get("lsp_symbols", []),
+                "diagnostics": metadata.get("lsp_diagnostics", []),
+                "note": "LSP semantic context - symbol names, types, and locations",
+            }
         else:
             # Raw file content
-            content = metadata.get("content", "")
-            content = json.dumps({"path": path, "content": content})
-
-        file_tokens = llm_limiter.count_tokens(content)
+            payload = {"path": path, "content": metadata.get("content", "")}
 
         # A single file larger than the whole batch budget would be flushed as a
         # solo batch (below) and sent whole — if it also exceeds the per-minute
         # token budget, the rate limiter can never admit it and livelocks the UI
         # forever. Truncate it to fit, like WebFetch/Shell bound their payloads.
-        per_file_budget = token_limit - base_overhead
-        if file_tokens > per_file_budget:
-            content = llm_limiter.truncate_text(content, per_file_budget)
-            content += "\n...[TRUNCATED]"
-            file_tokens = llm_limiter.count_tokens(content)
+        content = _fit_file_payload(payload, token_limit - base_overhead)
+        file_tokens = llm_limiter.count_tokens(content)
 
         if current_token_count + file_tokens + base_overhead > token_limit:
             if content_buffer:
@@ -366,6 +358,24 @@ async def _extract_info(
         await _run_repo_agent(agent, query, content_buffer, "files", extracted_infos)
 
     return extracted_infos
+
+
+def _fit_file_payload(payload: dict, budget: int) -> str:
+    """Serialize a per-file payload, truncating its text field to fit ``budget``.
+
+    Truncating the *serialized* string cut the JSON mid-string (unterminated,
+    no closing brace), so the extractor could misattribute the path/content
+    boundary. Truncate the dominant field and re-serialize instead — the
+    extractor always receives valid JSON.
+    """
+    content = json.dumps(payload)
+    if llm_limiter.count_tokens(content) <= budget:
+        return content
+    key = "content" if "content" in payload else "symbols"
+    text = payload[key] if isinstance(payload[key], str) else json.dumps(payload[key])
+    envelope = llm_limiter.count_tokens(json.dumps({**payload, key: ""}))
+    text = llm_limiter.truncate_text(text, max(budget - envelope, 1))
+    return json.dumps({**payload, key: text + "\n...[TRUNCATED]"})
 
 
 async def _summarize_info(

--- a/src/zrb/llm/tool/mcp.py
+++ b/src/zrb/llm/tool/mcp.py
@@ -122,17 +122,26 @@ def cap_mcp_result(result: Any) -> Any:
     A third-party MCP server can return an arbitrarily large payload; unbounded,
     it becomes a tool-return message that overflows ``llm_limiter``'s per-minute
     budget on the agent's next request, which then livelocks forever (the same
-    UI freeze WebFetch hit). Only string results are capped — structured results
-    (small dicts/lists the model needs intact) pass through unless their string
-    form alone blows past the cap, in which case the string form is returned.
+    UI freeze WebFetch hit). Only *text* is capped: strings directly, string
+    items inside sequences, and oversized dicts via their JSON form. Binary and
+    other rich content parts (e.g. pydantic-ai ``BinaryContent`` images) pass
+    through untouched — stringifying them would replace the image the model is
+    supposed to see with a truncated Python repr.
     """
     max_chars = CFG.LLM_MAX_OUTPUT_CHARS
     if isinstance(result, str):
         capped, _ = truncate_text(result, max_chars, keep="head")
         return capped
-    as_text = str(result)
-    if len(as_text) > max_chars:
-        capped, _ = truncate_text(as_text, max_chars, keep="head")
+    if isinstance(result, (list, tuple)):
+        return [cap_mcp_result(item) for item in result]
+    if isinstance(result, dict):
+        try:
+            as_json = json.dumps(result, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return result
+        if len(as_json) <= max_chars:
+            return result
+        capped, _ = truncate_text(as_json, max_chars, keep="head")
         return capped
     return result
 

--- a/src/zrb/llm/tool/shell.py
+++ b/src/zrb/llm/tool/shell.py
@@ -84,6 +84,7 @@ async def run_shell_command(
             "configuration."
         )
 
+    process = None
     try:
         process = await _start_process(argv, cwd)
         # _start_process creates the subprocess with stdout/stderr=PIPE, so both
@@ -132,6 +133,14 @@ async def run_shell_command(
 
     except Exception as e:
         _cleanup_temp_file(temp_pid_file)
+        # A failure after the process started (e.g. a stream error) must not
+        # leave the command running detached with no handle to it.
+        if process is not None and process.returncode is None:
+            await terminate_process(
+                process,
+                CFG.LLM_SHELL_KILL_WAIT_TIMEOUT / 1000,
+                print_method=CFG.LOGGER.warning,
+            )
         return (
             f"Error executing command: {e}. "
             "[SYSTEM SUGGESTION]: Check the command syntax and that any "
@@ -198,6 +207,10 @@ async def _start_process(argv: list[str], cwd: str) -> asyncio.subprocess.Proces
         stdin=asyncio.subprocess.DEVNULL,
         cwd=cwd,
         start_new_session=True,
+        # asyncio's default 64KB StreamReader limit makes readline() raise on a
+        # single long line (minified JS, one-line JSON logs), losing all output.
+        # ponytail: 8MB line ceiling; switch to chunked read() if ever exceeded.
+        limit=8 * 1024 * 1024,
     )
 
 

--- a/src/zrb/llm/tool/web.py
+++ b/src/zrb/llm/tool/web.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 from zrb.config.config import CFG
@@ -14,8 +15,16 @@ async def open_web_page(url: str, summarize: bool = True) -> dict:
     a sub-agent extracts high-signal content to reduce token usage.
     """
     try:
-        html_content, links = await _fetch_page_content(url)
-        markdown_content = _convert_html_to_markdown(html_content)
+        content, links, is_pdf = await _fetch_page_content(url)
+        # PDF text is already plain text — running it through the HTML
+        # converter would eat `<...>`-looking sequences (code, generics,
+        # emails) as if they were tags. The HTML conversion itself is
+        # blocking CPU (BeautifulSoup + markdownify), so it runs off-loop.
+        markdown_content = (
+            content
+            if is_pdf
+            else await asyncio.to_thread(_convert_html_to_markdown, content)
+        )
         # Bound the payload before it becomes a message, like Shell caps its
         # output: an unbounded page otherwise produces a request larger than the
         # per-minute token budget, which the rate limiter can never admit — it
@@ -210,10 +219,16 @@ def _error_result(query: str, page: int, message: str, backend: str) -> dict:
 
 
 async def _fetch_page_content(url: str) -> tuple:
+    """Fetch a URL. Returns ``(content, links, is_pdf)``.
+
+    Sync HTTP (requests) and PDF parsing (pdfplumber) run via
+    ``asyncio.to_thread`` — inline they freeze the TUI's event loop for the
+    whole download + parse.
+    """
     user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
     # A known .pdf extension lets us skip launching a browser entirely.
     if url.split("?")[0].lower().endswith(".pdf"):
-        return _fetch_pdf_content(url, user_agent)
+        return await asyncio.to_thread(_fetch_pdf_content, url, user_agent)
     try:
         # lazy: heavy third-party
         from playwright.async_api import async_playwright
@@ -233,7 +248,8 @@ async def _fetch_page_content(url: str) -> tuple:
             ):
                 data = await response.body()
                 await browser.close()
-                return _extract_pdf_text(data), []
+                text = await asyncio.to_thread(_extract_pdf_text, data)
+                return text, [], True
             content = await page.content()
             links = await page.eval_on_selector_all(
                 "a[href]",
@@ -241,33 +257,39 @@ async def _fetch_page_content(url: str) -> tuple:
                 url,
             )
             await browser.close()
-            return content, links
+            return content, links, False
     except Exception:
-        # lazy: deferred to keep module import light
-        from urllib.parse import urljoin
+        return await asyncio.to_thread(_fetch_page_fallback, url, user_agent)
 
-        # lazy: heavy third-party
-        import requests
-        from bs4 import BeautifulSoup
 
-        response = requests.get(
-            url,
-            headers={"User-Agent": user_agent},
-            timeout=CFG.LLM_WEB_HTTP_TIMEOUT / 1000,
-        )
-        response.raise_for_status()
-        if "application/pdf" in response.headers.get("Content-Type", "").lower():
-            return _extract_pdf_text(response.content), []
-        soup = BeautifulSoup(response.text, "html.parser")
-        links = [
-            urljoin(url, str(a["href"]))
-            for a in soup.find_all("a", href=True)
-            if not str(a["href"]).startswith("#")
-        ]
-        return response.text, links
+def _fetch_page_fallback(url: str, user_agent: str) -> tuple:
+    """Plain-HTTP fallback when playwright is unavailable or fails (sync, run off-loop)."""
+    # lazy: deferred to keep module import light
+    from urllib.parse import urljoin
+
+    # lazy: heavy third-party
+    import requests
+    from bs4 import BeautifulSoup
+
+    response = requests.get(
+        url,
+        headers={"User-Agent": user_agent},
+        timeout=CFG.LLM_WEB_HTTP_TIMEOUT / 1000,
+    )
+    response.raise_for_status()
+    if "application/pdf" in response.headers.get("Content-Type", "").lower():
+        return _extract_pdf_text(response.content), [], True
+    soup = BeautifulSoup(response.text, "html.parser")
+    links = [
+        urljoin(url, str(a["href"]))
+        for a in soup.find_all("a", href=True)
+        if not str(a["href"]).startswith("#")
+    ]
+    return response.text, links, False
 
 
 def _fetch_pdf_content(url: str, user_agent: str) -> tuple:
+    """Download and extract a PDF (sync, run off-loop)."""
     # lazy: heavy third-party
     import requests
 
@@ -277,7 +299,7 @@ def _fetch_pdf_content(url: str, user_agent: str) -> tuple:
         timeout=CFG.LLM_WEB_HTTP_TIMEOUT / 1000,
     )
     response.raise_for_status()
-    return _extract_pdf_text(response.content), []
+    return _extract_pdf_text(response.content), [], True
 
 
 def _extract_pdf_text(data: bytes) -> str:
@@ -288,9 +310,8 @@ def _extract_pdf_text(data: bytes) -> str:
     import pdfplumber
 
     with pdfplumber.open(io.BytesIO(data)) as pdf:
-        return "\n".join(
-            page.extract_text() for page in pdf.pages if page.extract_text()
-        )
+        texts = (page.extract_text() for page in pdf.pages)
+        return "\n".join(t for t in texts if t)
 
 
 def _convert_html_to_markdown(html_text: str) -> str:

--- a/src/zrb/llm/tool_call/argument_formatter/replace_in_file_formatter.py
+++ b/src/zrb/llm/tool_call/argument_formatter/replace_in_file_formatter.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 from typing import TYPE_CHECKING
@@ -5,6 +6,7 @@ from typing import TYPE_CHECKING
 from zrb.llm.tool_call.argument_formatter.util import format_diff
 from zrb.llm.tool_call.ui_protocol import UIProtocol
 from zrb.util.cli.markdown import render_markdown
+from zrb.util.cli.terminal import get_terminal_size
 
 if TYPE_CHECKING:
     from pydantic_ai import ToolCallPart
@@ -36,33 +38,43 @@ async def replace_in_file_formatter(
         if not path or old_text is None or new_text is None:
             return None
 
-        abs_path = os.path.abspath(os.path.expanduser(path))
-        if not os.path.exists(abs_path):
-            return None
-
-        with open(abs_path, "r", encoding="utf-8") as f:
-            content = f.read()
-
-        if old_text not in content:
-            return None
-
-        new_content = content.replace(old_text, new_text, count)
-        if content == new_content:
-            return None
-
-        diff_md = format_diff(content, new_content, path, ui=ui)
-        if not diff_md:
-            return None
-
-        indent = " " * 7
-        # Use width=None to let Rich handle markdown rendering without interfering
-        # with the already-wrapped diff formatting from util.py
-        formatted_diff = render_markdown(diff_md, width=None)
-        formatted_diff = "\n".join(
-            [f"{indent}{line}" for line in formatted_diff.splitlines()]
+        # Offload: file read + difflib + Rich markdown render is pure blocking
+        # CPU/IO. On the TUI it runs on prompt_toolkit's event loop before the
+        # approval prompt appears, so leaving it inline freezes keystrokes.
+        return await asyncio.to_thread(
+            _format_replace, path, old_text, new_text, count, ui
         )
-
-        return f"       📄 File: {path}\n" f"{formatted_diff}\n"
 
     except Exception:
         return None
+
+
+def _format_replace(path, old_text, new_text, count, ui) -> str | None:
+    abs_path = os.path.abspath(os.path.expanduser(path))
+    if not os.path.exists(abs_path):
+        return None
+
+    with open(abs_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if old_text not in content:
+        return None
+
+    new_content = content.replace(old_text, new_text, count)
+    if content == new_content:
+        return None
+
+    diff_md = format_diff(content, new_content, path, ui=ui)
+    if not diff_md:
+        return None
+
+    indent = " " * 7
+    # Render at the real terminal width. width=None makes Rich fall back to 80
+    # when stdout is a capture pipe (see get_terminal_size note), which re-wraps
+    # the already-wide diff lines from util.py.
+    formatted_diff = render_markdown(diff_md, width=get_terminal_size().columns)
+    formatted_diff = "\n".join(
+        [f"{indent}{line}" for line in formatted_diff.splitlines()]
+    )
+
+    return f"       📄 File: {path}\n{formatted_diff}\n"

--- a/src/zrb/llm/tool_call/argument_formatter/util.py
+++ b/src/zrb/llm/tool_call/argument_formatter/util.py
@@ -1,8 +1,9 @@
 import difflib
 import re
-import shutil
 import textwrap
 from typing import Any
+
+from zrb.util.cli.terminal import get_terminal_size
 
 
 def format_diff(
@@ -58,7 +59,11 @@ def format_diff(
         calculated_width = term_width - prefix_len - 10
     else:
         try:
-            term_width = shutil.get_terminal_size().columns
+            # Not shutil.get_terminal_size(): the TUI redirects stdout/stderr
+            # fds to a capture pipe, so that only sees a pipe and falls back to
+            # 80. The robust helper falls through to stdin (fd 0, not
+            # redirected) and recovers the real width.
+            term_width = get_terminal_size().columns
             calculated_width = term_width - prefix_len - 10
         except Exception:
             # Default to 80 if terminal detection fails

--- a/src/zrb/llm/tool_call/argument_formatter/write_file_formatter.py
+++ b/src/zrb/llm/tool_call/argument_formatter/write_file_formatter.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 from typing import TYPE_CHECKING
@@ -5,6 +6,7 @@ from typing import TYPE_CHECKING
 from zrb.llm.tool_call.argument_formatter.util import format_diff
 from zrb.llm.tool_call.ui_protocol import UIProtocol
 from zrb.util.cli.markdown import render_markdown
+from zrb.util.cli.terminal import get_terminal_size
 
 if TYPE_CHECKING:
     from pydantic_ai import ToolCallPart
@@ -35,7 +37,10 @@ async def write_file_formatter(
         if not path or content is None:
             return None
 
-        return _format_single_write(path, content, mode, ui)
+        # Offload: file read + difflib + Rich markdown render is pure blocking
+        # CPU/IO. On the TUI it runs on prompt_toolkit's event loop before the
+        # approval prompt appears, so leaving it inline freezes keystrokes.
+        return await asyncio.to_thread(_format_single_write, path, content, mode, ui)
 
     except Exception:
         return None
@@ -62,9 +67,10 @@ def _format_single_write(path: str, new_content: str, mode: str, ui) -> str | No
         return f"       📄 File: {path} (No changes)\n"
 
     indent = " " * 7
-    # Use width=None to let Rich handle markdown rendering without interfering
-    # with the already-wrapped diff formatting from util.py
-    formatted_diff = render_markdown(diff_md, width=None)
+    # Render at the real terminal width. width=None makes Rich fall back to 80
+    # when stdout is a capture pipe (see get_terminal_size note), which re-wraps
+    # the already-wide diff lines from util.py.
+    formatted_diff = render_markdown(diff_md, width=get_terminal_size().columns)
     formatted_diff = "\n".join(
         [f"{indent}{line}" for line in formatted_diff.splitlines()]
     )

--- a/src/zrb/llm/tool_call/handler.py
+++ b/src/zrb/llm/tool_call/handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -144,7 +145,11 @@ class ToolCallHandler:
         """
         args_section = ""
         if f"{call.args}" != "{}":
-            args_str = self._format_args(call.args)
+            # Offload: _format_args runs yaml_dump + a Rich markdown render, pure
+            # blocking CPU. On the TUI format_approval_message is awaited on
+            # prompt_toolkit's event loop before the prompt shows, so an inline
+            # render freezes keystrokes (measured ~700ms on a large Write).
+            args_str = await asyncio.to_thread(self._format_args, call.args)
             args_section = f"{args_str}\n"
 
         for formatter in self._argument_formatters:

--- a/src/zrb/llm/ui/default/output_mixin.py
+++ b/src/zrb/llm/ui/default/output_mixin.py
@@ -143,10 +143,17 @@ class OutputMixin:
         # Scrolling back down to the last line resumes following. Works
         # regardless of which pane is focused, so the thinking process can be
         # read mid-stream without first focusing the output pane (Ctrl+K).
+        #
+        # "Cursor on the last line" == "no newline after the cursor". Checked on
+        # the raw string on purpose: document.cursor_position_row/line_count
+        # build the Document's line index — an O(buffer) scan on EVERY streamed
+        # chunk (the render path rebuilds it anyway, but only at the debounced
+        # ~60Hz rate, not per token). str.find early-exits, so this is O(1)
+        # while following and O(distance to next newline) when scrolled up.
         is_at_last_line = True
         try:
-            doc = self._output_field.buffer.document
-            is_at_last_line = doc.cursor_position_row >= doc.line_count - 1
+            cursor = self._output_field.buffer.cursor_position
+            is_at_last_line = current_text.find("\n", cursor) == -1
         except Exception:
             pass
         should_scroll_to_end = is_at_last_line

--- a/test/llm/agent/test_common.py
+++ b/test/llm/agent/test_common.py
@@ -152,6 +152,40 @@ async def testcreate_safe_wrapper_handles_exception():
 
 
 @pytest.mark.asyncio
+async def testcreate_safe_wrapper_sync_function_runs_off_event_loop():
+    """Sync tools must not run inline on the event loop.
+
+    The wrapper is a coroutine function, so pydantic-ai never applies its own
+    executor offload — inline execution would freeze the TUI for the tool's
+    duration (e.g. ReadFile on a large file).
+    """
+    import threading
+
+    loop_thread = threading.current_thread()
+
+    def sync_func():
+        return threading.current_thread() is not loop_thread
+
+    wrapped = create_safe_wrapper(sync_func)
+    result = await wrapped()
+    assert result.return_value is True
+
+
+@pytest.mark.asyncio
+async def testcreate_safe_wrapper_propagates_model_retry():
+    """ModelRetry drives pydantic-ai's retry protocol — it must not be
+    flattened into an error-string ToolReturn."""
+    from pydantic_ai import ModelRetry
+
+    def retrying_func():
+        raise ModelRetry("try again with a narrower query")
+
+    wrapped = create_safe_wrapper(retrying_func)
+    with pytest.raises(ModelRetry):
+        await wrapped()
+
+
+@pytest.mark.asyncio
 async def testcreate_safe_wrapper_already_tool_return():
     """Test create_safe_wrapper when function already returns ToolReturn."""
     from pydantic_ai import ToolReturn

--- a/test/llm/prompt/test_manager.py
+++ b/test/llm/prompt/test_manager.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from zrb.config.config import CFG
 from zrb.context.shared_context import SharedContext
 from zrb.llm.prompt.manager import PromptManager, new_prompt
@@ -143,6 +145,30 @@ def test_create_live_context_wraps_volatile_state_in_tags():
     assert rendered.rstrip().endswith("</live-context>")
     # Volatile content lives here, not in the cached system prompt.
     assert "Time:" in rendered
+
+
+@pytest.mark.asyncio
+async def test_create_live_context_async_matches_sync_shape():
+    """The async twin (per-turn hot path, git off-loop) renders the same block
+    shape and honors custom providers, with ContextVar wiring on the loop."""
+    manager = PromptManager(include_sections=[])
+    manager.add_live_context("test_provider", lambda ctx: "- Custom: hello")
+    ctx = MagicMock()
+    ctx.input.session = "live-ctx-async-test"
+
+    with patch("zrb.llm.tool.plan.todo_manager") as mock_tm:
+        mock_tm.get_todos.return_value = None
+        rendered = await manager.create_live_context_async(ctx)
+
+    assert rendered.startswith("<live-context>")
+    assert rendered.rstrip().endswith("</live-context>")
+    assert "Time:" in rendered
+    assert "Custom: hello" in rendered
+
+    from zrb.llm.tool.ambient_state import get_current_tool_session
+
+    # The wiring side effect must land in the caller's context, not a thread's.
+    assert get_current_tool_session() == "live-ctx-async-test"
 
 
 def test_add_live_context_appends_custom_content():

--- a/test/llm/tool/test_code.py
+++ b/test/llm/tool/test_code.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -443,3 +444,8 @@ async def test_extract_info_truncates_oversized_single_file():
     joined = "".join(captured[0])
     assert "[TRUNCATED]" in joined
     assert llm_limiter.count_tokens(joined) <= 1000
+    # Truncation must happen inside the content field, not by cutting the
+    # serialized string — the extractor must always receive valid JSON.
+    parsed = json.loads(captured[0][0])
+    assert parsed["path"] == "big.py"
+    assert parsed["content"].endswith("[TRUNCATED]")

--- a/test/llm/tool/test_mcp.py
+++ b/test/llm/tool/test_mcp.py
@@ -33,6 +33,30 @@ def test_cap_mcp_result_caps_oversized_structured():
     assert len(out) < 600
 
 
+def test_cap_mcp_result_passes_binary_through_intact():
+    """A large image must never be stringified into a truncated repr.
+
+    Regression: capping via str(result) turned MCP screenshot results into
+    "BinaryContent(data=b'\\x89PNG..." head text, losing the image entirely.
+    """
+    from pydantic_ai.messages import BinaryContent
+
+    image = BinaryContent(data=b"\x89PNG" * 100_000, media_type="image/png")
+    with patch.dict(os.environ, {f"{CFG.ENV_PREFIX}_LLM_MAX_OUTPUT_CHARS": "500"}):
+        assert cap_mcp_result(image) is image
+
+
+def test_cap_mcp_result_caps_text_items_but_keeps_binary_in_list():
+    from pydantic_ai.messages import BinaryContent
+
+    image = BinaryContent(data=b"\x89PNG" * 100_000, media_type="image/png")
+    with patch.dict(os.environ, {f"{CFG.ENV_PREFIX}_LLM_MAX_OUTPUT_CHARS": "500"}):
+        out = cap_mcp_result([image, "z" * 5000, "short"])
+    assert out[0] is image
+    assert "[TRUNCATED]" in out[1] and len(out[1]) < 600
+    assert out[2] == "short"
+
+
 @pytest.fixture
 def mock_fs():
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/test/llm/tool/test_shell.py
+++ b/test/llm/tool/test_shell.py
@@ -234,6 +234,19 @@ async def test_run_shell_command_timeout():
 
 
 @pytest.mark.asyncio
+async def test_run_shell_command_survives_long_single_line():
+    # Regression: asyncio's default 64KB StreamReader limit made readline()
+    # raise on one long line (minified JS, single-line JSON), losing all output
+    # and leaving the process running detached.
+    res = await run_shell_command(
+        "python3 -c \"print('x' * 200000)\"", max_chars=300000
+    )
+    assert "Exit Code: 0" in res
+    assert "xxxx" in res
+    assert "Error executing command" not in res
+
+
+@pytest.mark.asyncio
 async def test_run_shell_command_pid_file_cleanup_failure_is_ignored(monkeypatch):
     # Collecting background PIDs is best-effort: a failure removing the temp PID
     # file is swallowed and the command result is still returned.

--- a/test/llm/tool/test_web_tool.py
+++ b/test/llm/tool/test_web_tool.py
@@ -216,6 +216,32 @@ async def test_open_web_page_pdf_url_skips_playwright():
         assert result["links_on_page"] == []
         mock_pdf_open.assert_called_once()
         mock_playwright.assert_not_called()
+        # pdfplumber's extract_text is expensive; it must run once per page,
+        # not once for the emptiness filter and again for the join.
+        assert fake_page.extract_text.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_open_web_page_pdf_text_not_html_converted():
+    # PDF text containing <...> sequences (code, generics, emails) must survive:
+    # running it through the HTML→markdown converter eats them as tags.
+    fake_page = MagicMock()
+    fake_page.extract_text.return_value = "compile with #include <stdio.h> today"
+    fake_pdf = MagicMock()
+    fake_pdf.pages = [fake_page]
+    fake_pdf.__enter__.return_value = fake_pdf
+
+    with (
+        patch("requests.get") as mock_get,
+        patch("pdfplumber.open", return_value=fake_pdf),
+    ):
+        mock_response = MagicMock()
+        mock_response.content = b"%PDF-1.4 ..."
+        mock_get.return_value = mock_response
+
+        result = await open_web_page("https://example.com/doc.pdf", summarize=False)
+
+        assert "<stdio.h>" in result["content"]
 
 
 @pytest.mark.asyncio
@@ -301,6 +327,11 @@ async def test_open_web_page_with_summarization():
         patch("playwright.async_api.async_playwright") as mock_playwright_ctx,
         patch("zrb.llm.tool.web.create_agent") as mock_create_agent,
         patch("zrb.llm.tool.web.run_agent", new_callable=AsyncMock) as mock_run_agent,
+        # The fallback must never be reached: with goto unstubbed, the
+        # content-type check exploded on an auto-AsyncMock (leaking a
+        # never-awaited coroutine) and the test silently fetched the real
+        # https://example.com through requests. Fail loudly instead.
+        patch("requests.get", side_effect=AssertionError("network escape")),
     ):
 
         mock_p = AsyncMock()
@@ -311,6 +342,9 @@ async def test_open_web_page_with_summarization():
         mock_p.chromium.launch.return_value = mock_browser
         mock_browser.new_page.return_value = mock_page
 
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "text/html"}
+        mock_page.goto.return_value = mock_response
         mock_page.content.return_value = "<html><body><h1>Title</h1><p>Content with lots of details that should be summarized.</p></body></html>"
         mock_page.eval_on_selector_all.return_value = ["https://example.com/link"]
 

--- a/test/llm/tool_call/argument_formatter/test_util.py
+++ b/test/llm/tool_call/argument_formatter/test_util.py
@@ -88,6 +88,28 @@ class TestFormatDiff:
         # With wrapping, we might have multiple continuation lines
         assert len(plus_lines) >= 1
 
+    def test_format_diff_auto_detects_wide_terminal(self):
+        """Auto width detection must use the stdin-aware get_terminal_size.
+
+        Regression: the TUI redirects stdout/stderr fds to a capture pipe, so
+        shutil.get_terminal_size() (stdout-only) falls back to 80 and long diff
+        lines wrap at ~62. The robust helper recovers the real width. Patching
+        it here proves format_diff reads that width (no-op if it were shutil).
+        """
+        long_line = "x" * 160
+        wide = Mock()
+        wide.columns = 200
+        with patch(
+            "zrb.llm.tool_call.argument_formatter.util.get_terminal_size",
+            return_value=wide,
+        ):
+            result = format_diff("short", long_line, "test.txt")
+
+        # The 160-char line fits within 200 cols, so it is NOT wrapped down to
+        # the ~62-col (80 - prefix) width the old shutil fallback produced.
+        widest = max(len(line) for line in result.split("\n"))
+        assert widest > 100
+
     def test_format_diff_with_ui_parameter(self):
         """Test format_diff with UI parameter for width detection."""
         ui = Mock()


### PR DESCRIPTION
# Summary


### 1. TUI event-loop offloading (biggest chunk)
The TUI freezes whenever a blocking operation runs inline on prompt_toolkit's event loop. This branch moves the hot-path offenders to `asyncio.to_thread()`:

| Caller | What was offloaded |
|---|---|
| `llm_task.py` | `history_manager.load()` and `.save()` (serializes/deserializes the whole conversation) |
| `live_context.py` | Git subprocesses (`git status` etc.) — new `render_live_context_async()` twin; ContextVar wiring stays on the caller's thread |
| `prompt/manager.py` + `builder_mixin.py` | Plumbing for the async twin |
| `agent/common.py` | **Sync tools** now run via `to_thread` (the wrapper is a coroutine, so pydantic-ai never applies its own executor) |
| `tool_call/handler.py` | `_format_args()` (yaml + Rich markdown render) |
| `replace_in_file_formatter.py` + `write_file_formatter.py` | File read + difflib + Rich render |
| `tool/web.py` | `requests.get`, pdfplumber, HTML→markdown conversion (BeautifulSoup is blocking CPU) |

All new async paths are additive (sync callers still work unchanged).

---

### 2. Markdown/diff width fix
`shutil.get_terminal_size()` reads stdout fd, which the TUI redirects to a capture pipe → always sees width=80 → diffs re-wrap at ~62 cols. **Fix:** a new `get_terminal_size()` helper (`util/cli/terminal.py`) falls through to stdin (fd 0, not redirected) and recovers the real terminal width. Used in `format_diff`, `replace_in_file_formatter`, and `write_file_formatter`.

---

### 3. Tool correctness fixes

- **`code.py`** — Truncation now happens *inside* the JSON `content` field, not by slicing the serialized string (which produced unterminated JSON). New `_fit_file_payload()` helper truncates the dominant field, then re-serializes. Test verifies the output is valid JSON.
- **`mcp.py`** — `cap_mcp_result()` no longer stringifies everything. Lists/tuples are recursed into; dicts are truncated via their JSON form; **binary content (e.g. `BinaryContent` images) passes through untouched** — stringifying them was replacing the image with a truncated Python repr.
- **`shell.py`** — `StreamReader` limit raised from 64KB → 8MB (minified JS / one-line JSON logs were hitting it, losing all output). Plus: if the process started but a later exception occurs, it is now terminated instead of left running detached.

---

### 4. PDF handling
- PDF text now bypasses HTML→markdown conversion (BeautifulSoup eats `<...>` sequences as tags).
- A refactor extracted `_fetch_page_fallback()` (sync requests+BS4 path) as a standalone function, run via `to_thread`.
- pdfplumber `extract_text()` runs once per page (was called twice due to the emptiness filter).

---

### 5. History file safety
`_save_data_to_file` now writes to a sibling `.tmp` file and `os.replace()`s into place, preventing crash-mid-write corruption. Cleanup on error.

---

### 6. Minor optimizations / correctness
- **`output_mixin.py`** — "At last line?" check switched from `Document.cursor_position_row` (O(buffer) scan per token) to `str.find("\n", cursor)` (O(1) while following).
- **`agent/common.py`** — `ModelRetry` exceptions now propagate to pydantic-ai's retry protocol instead of being swallowed as error strings.

---

### Tests
New tests cover: sync-off-event-loop execution, `ModelRetry` propagation, async live-context parity, oversized-file JSON validity after truncation, MCP binary passthrough, shell long-line survival, PDF `<...>` preservation, and terminal width auto-detection.

---



# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review

# Ticket or Issue

> Ticket or issue number if applicable.

# How to Test

> How to test that this PR works.