### PR TITLE
Add framework conventions rulebook and pattern decision table (Phase 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,9 @@ Lives under `docs/`: `changelog.md` (index), `changelog-v2/` (per-minor files, e
 
 ## Development Conventions
 
+> New here? Start at [Which pattern do I reach for?](docs/advanced-topics/which-pattern.md).
+> The enforced rule list is [Framework Conventions](docs/advanced-topics/framework-conventions.md) (R1–R12). Cite rule numbers in review.
+
 ### Code Style
 
 - Follow existing project conventions (formatting, naming, typing).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,6 @@ Zrb (Zaruba) is a Python-based automation and AI-agent framework — see [README
 
 **Read the [Maintainer Guide → Getting Started](docs/advanced-topics/maintainer-guide.md#getting-started) first.** It covers environment setup, running the test suite, what to do when a check fails, and how to submit a pull request (branch naming, commits, changelog entries, ADRs).
 
+Then, before writing any code, check [Which pattern do I reach for?](docs/advanced-topics/which-pattern.md) — a one-page lookup table for the pattern zrb expects for the thing you're adding.
+
 For code-level conventions — naming, testing, imports, error handling, module layout — see [`AGENTS.md`](AGENTS.md) at the repo root. It's written for AI coding agents, but every rule in it applies to human contributors too.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ All task types available in Zrb, from basic to advanced.
 - [Claude Code Compatibility](docs/advanced-topics/claude-compatibility.md)
 
 ### IV. Advanced Topics
+- [Which pattern do I reach for?](docs/advanced-topics/which-pattern.md) — lookup table for the pattern zrb expects when adding new code
 - [Architecture & Conventions](docs/advanced-topics/architecture.md) — for maintainers and contributors
 - [Web UI Guide](docs/advanced-topics/web-ui.md)
 - [White-labeling: Create a Custom CLI](docs/advanced-topics/white-labeling.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,6 +4,8 @@
 
 This directory records **why** zrb is built the way it is. Every record describes a decision **that is currently in force**, with the alternatives that were rejected and why.
 
+New here? [Which pattern do I reach for?](../advanced-topics/which-pattern.md) is a one-page lookup table that answers most "which ADR applies to what I'm adding" questions without reading the log; [Framework Conventions](../advanced-topics/framework-conventions.md) lists the enforced R1–R12 rules.
+
 ## How to read an entry
 
 Every ADR has the same shape:

--- a/docs/advanced-topics/framework-conventions.md
+++ b/docs/advanced-topics/framework-conventions.md
@@ -1,0 +1,26 @@
+🔖 [Documentation Home](../../README.md) > [Advanced Topics](./) > Framework Conventions
+
+# Framework Conventions (R1–R12)
+
+These are the rules a zrb component must follow to be predictable. Each is enforced by a test in `test/architecture/`; the table names which. Cite the rule number in review.
+
+| # | Rule | Enforced by |
+| --- | --- | --- |
+| **R1** | Assigning an unknown `CFG.UPPERCASE` name raises `AttributeError` naming the closest real knob. | Phase 1 |
+| **R2** | Assigning a value `CFG` cannot cast back raises `ValueError` at the assignment, not at the next read. | Phase 1 |
+| **R3** | No `CFG.X` read happens at import time. A config value consumed by a component defined at import time is wrapped in a callable. | Phase 2 ratchet |
+| **R4** | A failure loading `zrb_init.py` prints the file, line and exception type, and exits non-zero. Partial config is never silently accepted. | Phase 2 |
+| **R5** | **Ordered** collections (prompts, tools, policies, formatters, processors) expose exactly `append_X`, `prepend_X`, `set_X`, `remove_X`. No `add_X`. | Phase 3 ratchet |
+| **R6** | **Name-keyed** collections (skills, agents, hooks, UIs) expose exactly `add_X`, `set_X`, `remove_X(name)`, `get_X(name)`, `get_Xs()`. | Phase 3 ratchet |
+| **R7** | A concept is reachable by exactly one name. No `set_history_manager()` *and* a settable `history_manager` property. No `search_dirs` property *and* `get_search_directories()`. | Phase 3 ratchet |
+| **R8** | Every component a user may replace is a settable property on its host, typed as the component's `Any*` ABC or concrete class. | Phase 4 ratchet |
+| **R9** | Every abstract extension point is named `Any<Thing>` and lives in `any_<thing>.py` in the package that owns the concept. | Phase 8, Phase 9 |
+| **R10** | An error the *LLM* must recover from carries `[SYSTEM SUGGESTION]` (ADR-0057). An error the *user* must fix names the setting, the bad value and the accepted values. Never bare `Exception`. | Phase 9 ratchet |
+| **R11** | Sibling classes in one package use one naming convention. Two conventions for the same role is a bug. | Phase 9 |
+| **R12** | Every registry has exactly one canonical instance, module-level, exported from `zrb/__init__.py`. No private second registry for the same family. | Phase 7 |
+
+See also: [Which pattern do I reach for?](which-pattern.md) — a lookup table for picking the right rule/pattern when adding new code.
+
+---
+
+🔖 [Documentation Home](../../README.md) > [Advanced Topics](./) > Framework Conventions

--- a/docs/advanced-topics/which-pattern.md
+++ b/docs/advanced-topics/which-pattern.md
@@ -1,0 +1,46 @@
+🔖 [Documentation Home](../../README.md) > [Advanced Topics](./) > Which pattern do I reach for?
+
+# Which pattern do I reach for?
+
+Ten patterns carry most of zrb. This page is a lookup table, not a tutorial — find the row that matches what you are adding, then read the ADR it names if you need the reasoning. Every row is enforced by a test or an ADR; nothing here is style preference.
+
+| I am adding… | Use | Not | Why / enforced by |
+| --- | --- | --- | --- |
+| A scalar setting a user may set from the environment or `zrb_init.py` | An `EnvField` on the matching `config/mixins/*.py` mixin, with a `DEFAULT_<NAME>` | a constructor parameter, a module-level constant | ADR-0021, ADR-0022 |
+| A value that must not be read until run time | An `*Attr` type from `zrb/attr/type.py` plus `get_*_attr`, or a zero-arg callable | reading `CFG.X` in `__init__` or at module scope | ADR-0005, R3 |
+| One more item in a collection users already extend (tools, prompts, skills, agents, hooks) | `append_X`/`add_X` on that family's registry | a new registry, a new constructor parameter | ADR-0091, R5/R6 |
+| A whole new family of user-extensible components | A registry + a manager + a `CFG` name-allowlist twin, all three | a bare module-level list | ADR-0090, ADR-0091 |
+| Behavior that any unrelated class could mix in, reading only state it sets itself | A `*Mixin` class | a composed part | ADR-0035, R11 |
+| Behavior that reads state only one host provides | A composed part, `<Owner><Aspect>` in a file named for the aspect, reached through the owner's **public** accessors | a Mixin, or inheritance | ADR-0035; `test_boundaries.py` |
+| A component a user may replace wholesale | An `Any*` ABC in `any_<thing>.py` **plus** a settable, non-`Any`-typed property on the host | a constructor parameter alone | R8, R9 |
+| Ambient state that must follow a run without being threaded through every call | A `ContextVar` plus a typed wrapper, re-exported from `zrb/contextvars.py` | a module global, `threading.local` | ADR-0004 |
+| A new agent-callable tool | A module under `llm/tool/`, **plus** registration **and** a `tag(fn, Capability.X)` in `llm/common_tools.py` | the module alone — it silently becomes `Capability.UNKNOWN`, denied in plan mode | `test/llm/test_common_tools.py` |
+| A new user-executable task | A module under `builtin/`, **plus** an import in `builtin/__init__.py` **and** an `__all__` entry | the module alone — it silently never appears in the CLI | `test/builtin/test_registration_completeness.py` |
+| An error the **LLM** must recover from | A `[SYSTEM SUGGESTION]` prefix naming the actionable next step | a plain `ValueError` | ADR-0057, R10 |
+| An error a **user** must fix | The setting name, the bad value, and the accepted values | `raise Exception`, or a message under 40 characters | R10 |
+| An import of a heavy or cyclic dependency | An in-function import with a `# lazy: <reason>` tag matching one of the four categories | a module-level import | `test_lazy_import_categories.py` |
+| A decision a reasonable developer could make differently | An ADR in `docs/adr/`, and a **rewrite** of the record that owns the decision if one exists | a "supersedes ADR-NNNN" record | `docs/adr/README.md` |
+
+## The one hard call: Mixin vs. part
+
+Every row above is a lookup except this one, which is the one genuine judgement call in the codebase: both a `Mixin` and a part are "a class that adds behavior to a host," the rule is subtle, and it is unenforced by any single test on its own — it relies on the boundary tests plus review.
+
+> **Ask: does this class read any attribute it does not itself set?**
+>
+> **No** — every piece of state it touches, it assigns. Then any class can mix it in, and it is a `*Mixin`. Examples: `BufferedOutputMixin`, the `CFG` mixins.
+>
+> **Yes** — it reads something only one host provides. Then it is a *part* of that host, and parts are **composed, not inherited**: the owner does `self._aspect = OwnerAspect(self)` and re-exposes each method as a one-line delegator. Examples: `LLMTaskBuilding`, `ChatExecution`, `BaseUICommands`.
+>
+> **How a part reaches what it needs**, cheapest first: plain data → pass it as an argument. One sibling's behavior → hold that sibling. Behavior spread across siblings or the owner → hold the owner, and read it **only** through a public property or method. If the owner has no public accessor for that state, add one; that one line is the point, not a step to skip.
+>
+> **Never** `self._owner._x` or `self._part._method()`. If the thing on the other side needs reaching, expose it.
+>
+> On a class users subclass (`BaseTask`, `BaseUI`), the part's attribute is `self._base_<aspect>`, because a subclass author will independently reach for the short obvious name and `super().__init__()` runs first, so their assignment silently wins with no error.
+
+This is condensed from ADR-0035 and `AGENTS.md`. Do not paraphrase loosely — the `_base_` rule and the no-private-crossing rule are both enforced by `test/architecture/test_boundaries.py`, so getting the wording wrong sends someone into a failing test with no explanation.
+
+See also: [Framework Conventions (R1–R12)](framework-conventions.md).
+
+---
+
+🔖 [Documentation Home](../../README.md) > [Advanced Topics](./) > Which pattern do I reach for?


### PR DESCRIPTION
Gives newcomers one page to answer "which pattern do I reach for?" instead of reading 2,000 lines of ADR, plus the R1-R12 enforced rule list that later phases cite. ADR-0091 Part 2 already treats hooks as a name-keyed collection (add_X/set_X/remove_X), so no amendment was needed there — the register()/clear_manual() verb exception only exists in docs/configuration/llm-collections.md and the hook registry source, which Phase 3 will fix in code.

# Summary

> Description of the PR.

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review
- [ ] Added a changelog entry (or N/A) — see [Maintainer Guide → Changelog](https://github.com/state-alchemists/zrb/blob/main/docs/advanced-topics/maintainer-guide.md#changelog)
- [ ] Added an ADR, or this isn't a non-trivial/consequential/persistent decision (N/A) — see [`docs/adr/README.md`](https://github.com/state-alchemists/zrb/blob/main/docs/adr/README.md)

# Ticket or Issue

> Ticket or issue number if applicable.

# How to Test

> How to test that this PR works.