### PR TITLE
Fix macos osascript

### DIFF
--- a/src/zrb/llm/util/clipboard.py
+++ b/src/zrb/llm/util/clipboard.py
@@ -79,23 +79,25 @@ async def _macos_osascript() -> bytes | None:
         "  end try\n"
         "end try"
     )
-    proc = await asyncio.create_subprocess_exec(
-        "osascript",
-        "-e",
-        script,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    await proc.communicate()
     try:
+        proc = await asyncio.create_subprocess_exec(
+            "osascript",
+            "-e",
+            script,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.communicate()
         with open(tmp, "rb") as fh:
             data = fh.read()
     except OSError:
+        # Missing osascript, or it wrote nothing.
         data = b""
-    try:
-        os.unlink(tmp)
-    except OSError:
-        pass
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
     return data or None
 
 

--- a/src/zrb/llm/util/clipboard.py
+++ b/src/zrb/llm/util/clipboard.py
@@ -63,7 +63,10 @@ async def _macos() -> bytes | None:
 
 async def _macos_osascript() -> bytes | None:
     """Fallback: dump clipboard PNG via AppleScript when Pillow is absent."""
-    tmp = os.path.join(tempfile.gettempdir(), "zrb_clipboard_img.png")
+    # Unique per call: a fixed name would hand back a stale image from an
+    # earlier run whenever AppleScript writes nothing.
+    fd, tmp = tempfile.mkstemp(prefix="zrb_clipboard_img", suffix=".png")
+    os.close(fd)
     script = (
         "try\n"
         "  set imgData to (the clipboard as \u00abclass PNGf\u00bb)\n"
@@ -84,15 +87,16 @@ async def _macos_osascript() -> bytes | None:
         stderr=asyncio.subprocess.DEVNULL,
     )
     await proc.communicate()
-    if os.path.exists(tmp) and os.path.getsize(tmp) > 0:
+    try:
         with open(tmp, "rb") as fh:
             data = fh.read()
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        return data
-    return None
+    except OSError:
+        data = b""
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    return data or None
 
 
 # ---------------------------------------------------------------------------

--- a/test/builtin/test_explain_config.py
+++ b/test/builtin/test_explain_config.py
@@ -16,6 +16,15 @@ def _printed_text(mock_print) -> str:
     return _ANSI.sub("", raw)
 
 
+_WIDTH = 100
+
+
+@pytest.fixture(autouse=True)
+def fixed_terminal_width(monkeypatch):
+    """Rendering is terminal-width driven; pin it so assertions are stable."""
+    monkeypatch.setenv("COLUMNS", str(_WIDTH))
+
+
 @pytest.fixture
 def mock_print():
     return mock.MagicMock()
@@ -120,7 +129,7 @@ async def test_explain_config_list_view_keeps_values_on_one_line(session, mock_p
     printed = _printed_text(mock_print)
     for line in printed.splitlines():
         if line.startswith("ZRB_"):
-            assert len(line) < 200
+            assert len(line) <= _WIDTH
 
 
 @pytest.mark.asyncio

--- a/test/llm/util/test_clipboard_macos.py
+++ b/test/llm/util/test_clipboard_macos.py
@@ -315,3 +315,41 @@ async def test_macos_osascript_unlink_failure_does_not_propagate(clean_env, tmp_
             result = await get_clipboard_image()
 
     assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_macos_osascript_returns_none_when_binary_is_missing(
+    clean_env, tmp_path
+):
+    """No osascript on PATH: no image, and no tempfile left behind."""
+    clean_env.setattr("sys.platform", "darwin")
+    clean_env.setattr("tempfile.tempdir", str(tmp_path))
+    _block_pil_import(clean_env)
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        new=AsyncMock(side_effect=FileNotFoundError("osascript")),
+    ):
+        result = await get_clipboard_image()
+
+    assert result is None
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_macos_osascript_removes_tempfile_when_subprocess_raises(
+    clean_env, tmp_path
+):
+    """Cleanup also runs for failures the read path does not catch."""
+    clean_env.setattr("sys.platform", "darwin")
+    clean_env.setattr("tempfile.tempdir", str(tmp_path))
+    _block_pil_import(clean_env)
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await get_clipboard_image()
+
+    assert result is None
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
# Summary

`src/zrb/llm/util/clipboard.py:64-96` — _macos_osascript used a fixed `/tmp/zrb_clipboard_img.png`, so a leftover file (the unlink-failure test deliberately leaves one) got read back as "the clipboard" on the next run. Now tempfile.mkstemp per call, and the file is unlinked unconditionally instead of only on the success path.

# Checklist

- [x] The PR is compatible with Zrb's license
- [x] The PR is ready for review
- [x] Added a changelog entry (or N/A) — see [Maintainer Guide → Changelog](https://github.com/state-alchemists/zrb/blob/main/docs/contributing/maintainer-guide.md#changelog)
- [x] Added an ADR, or this isn't a non-trivial/consequential/persistent decision (N/A) — see [`docs/adr/README.md`](https://github.com/state-alchemists/zrb/blob/main/docs/adr/README.md)

# Ticket or Issue

> Ticket or issue number if applicable.

# How to Test

> How to test that this PR works.